### PR TITLE
documentation: build man pages with help2man

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,9 @@ AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AC_PROG_RANLIB
 
+AC_PATH_PROGS(HELP2MAN, help2man)
+AM_CONDITIONAL(HAVE_HELP2MAN, test x"${HELP2MAN}" != x"")
+
 # Checks for libraries.
 AC_CHECK_LIB([dl], [dlopen])
 AC_CHECK_LIB([pthread], [pthread_create])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,5 +15,14 @@ boothd_LDFLAGS		= $(OS_DYFLAGS) -L./
 noinst_HEADERS		= booth.h list.h pacemaker.h paxos_lease.h timer.h \
 			  config.h log.h paxos.h ticket.h transport.h
 
+if HAVE_HELP2MAN
+man_MANS		= booth.8 boothd.8
+MAINTAINERCLEANFILES	+= $(man_MANS)
+EXTRA_DIST		= $(man_MANS)
+
+%.8: %
+	$(HELP2MAN) -N -o $@ ./$<
+endif
+
 lint:
 	-splint $(INCLUDES) $(LINT_FLAGS) $(CFLAGS) *.c


### PR DESCRIPTION
Hi Jiaju,

please consider pulling this relatively trivial patch. Pending someone writing "real" man pages for booth and boothd, we can use help2man to generate them from --help.

Cheers,
Florian
