### PR TITLE
man page generation: actually create section 8 man pages, don't just pretend to

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,7 +21,7 @@ MAINTAINERCLEANFILES	+= $(man_MANS)
 EXTRA_DIST		= $(man_MANS)
 
 %.8: %
-	$(HELP2MAN) -N -o $@ ./$<
+	$(HELP2MAN) -s 8 -N -o $@ ./$<
 
 booth.8: boothd.8
 	cp $< $@


### PR DESCRIPTION
Hi Jiaju,

please pull this trivial fix to the way helpman is invoked. Without it, booth builds section 1 man pages with a .8 suffix.

Thanks,
Florian
