### PR TITLE
Merge cc_supports_flag implementation from pacemaker

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,12 +126,10 @@ AC_CONFIG_FILES([Makefile
 
 ## helper for CC stuff
 cc_supports_flag() {
-	local CPPFLAGS="$CPPFLAGS $@"
-	AC_MSG_CHECKING([whether $CC supports "$@"])
-	AC_PREPROC_IFELSE([AC_LANG_PROGRAM([])],
-			  [RC=0; AC_MSG_RESULT([yes])],
-			  [RC=1; AC_MSG_RESULT([no])])
-	return $RC
+         local CFLAGS="-Werror $@"
+         AC_MSG_CHECKING(whether $CC supports "$@")
+         AC_COMPILE_IFELSE([int main(){return 0;}] ,[RC=0; AC_MSG_RESULT(yes)],[RC=1; AC_MSG_RESULT(no)])
+         return $RC
 }
 
 ## cleanup


### PR DESCRIPTION
Main change is:

Check for compiler flags with -Werror

For example for -fstack-protector, it is accepted by gcc for
all targets, however those targets where it is actually not
supported, it will print a warning like

"-fstack-protector is not supported for this platform"

which raises an error when using -Werror later. So better
not add -fstack-protector then to the CC_EXTRA_FLAGS
