### PR TITLE
Fix: Add check to prevent segfault

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -122,9 +122,13 @@ static void update_ticket_from_msg(struct ticket_config *tk,
 static void copy_ticket_from_msg(struct ticket_config *tk,
 		struct boothc_ticket_msg *msg)
 {
-	tk->term_expires = time(NULL) + ntohl(msg->ticket.term_valid_for);
-	tk->current_term = ntohl(msg->ticket.term);
-	tk->commit_index = ntohl(msg->ticket.leader_commit);
+	if (msg) {
+		tk->term_expires = time(NULL) + ntohl(msg->ticket.term_valid_for);
+		tk->current_term = ntohl(msg->ticket.term);
+		tk->commit_index = ntohl(msg->ticket.leader_commit);
+	} else {
+		tk->term_expires = time(NULL) + tk->term_duration;
+	}
 }
 
 static void become_follower(struct ticket_config *tk,


### PR DESCRIPTION
The second argument of **copy_ticket_from_msg()** needs to be checked, since it may be NULL.
- [src/raft.c#L235](https://github.com/ClusterLabs/booth/blob/63c9085e88/src/raft.c#L235)

```
235                 become_follower(tk, NULL);
```
- [src/raft.c#L133](https://github.com/ClusterLabs/booth/blob/63c9085e88/src/raft.c#L133)

```
130 static void become_follower(struct ticket_config *tk,
131                 struct boothc_ticket_msg *msg)
132 {
133         copy_ticket_from_msg(tk, msg);
```
- [src/raft.c#L125](https://github.com/ClusterLabs/booth/blob/63c9085e88/src/raft.c#L125)

```
122 static void copy_ticket_from_msg(struct ticket_config *tk,
123                 struct boothc_ticket_msg *msg)
124 {
125         tk->term_expires = time(NULL) + ntohl(msg->ticket.term_valid_for);
```

I set the _time(NULL) + tk->term_duration_ to _tk->term_expires_ if _msg_ is NULL, referring to the [update_ticket_from_msg()](https://github.com/ClusterLabs/booth/blob/63c9085e88/src/raft.c#L106).
