### PR TITLE
Dev: Add a function not to grant a specific ticket at a specific site

### DIFF
--- a/docs/boothd.8.txt
+++ b/docs/boothd.8.txt
@@ -245,6 +245,10 @@ See below for details about booth specific environment variables
 and the distributed 'service-runnable' script.
 
 
+*'exclude_site'*::
+	The specified 'site' doesn't grant this ticket.
+
+
 A more verbose example of a configuration file might be
 
 -----------------------

--- a/src/config.h
+++ b/src/config.h
@@ -33,6 +33,14 @@
 #define TICKET_ALLOC	16
 
 
+struct exclude_site_config {
+	/** site ID (maps site_id of struct booth_site). */
+	int id;
+
+	/** IP address of site. */
+	char addr[BOOTH_NAME_LEN];
+};
+
 
 struct ticket_config {
 	/** \name Configuration items.
@@ -180,6 +188,12 @@ struct ticket_config {
 	 * Starts at 0, counts up. */
 	int retry_number;
 	/** @} */
+
+	int exclude_site_count;
+	int exclude_site_allocated;
+
+	/** Sites which don't grant this ticket. */
+	struct exclude_site_config *exclude_site;
 };
 
 

--- a/src/raft.c
+++ b/src/raft.c
@@ -693,7 +693,17 @@ int new_election(struct ticket_config *tk,
 {
 	struct booth_site *new_leader;
 	time_t now;
+	int i;
 
+
+	for (i = 0; i < tk->exclude_site_count; i++) {
+		if (local->site_id == tk->exclude_site[i].id) {
+			tk_log_info("cannot grant here because it's "
+				"an excepted ticket on the own site");
+			ticket_next_cron_in(tk, 3600);
+			return 0;
+		}
+	}
 
 	time(&now);
 	tk_log_debug("start new election?, now=%" PRIi64 ", end %" PRIi64,


### PR DESCRIPTION
This request is a proposal patch about exclusion of the ticket, adds a function which does not grant that ticket to the site specified by exclude_site in booth.conf.

**The example for which this function is needed.**
- There are three sites. I want to operate two services (two tickets).
- However, I want to operate only one service at one site.

**example of configuration**

```
site="192.168.203.101"
site="192.168.203.102"
site="192.168.203.103"

ticket="ticketA"
        exclude_site = 192.168.203.102
ticket="ticketB"
        exclude_site = 192.168.203.101
```
- Then, I grant **ticketA** to **192.168.203.101** and **ticketB** to **192.168.203.102**.
- By doing so, **only 192.168.203.103** becomes a **standby site** of ticketA and ticketB.
