### PR TITLE
Modified to use PACKAGE_VERSION to the initial value

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,7 +186,7 @@ test -s .git_info &&
 AC_ARG_WITH([build-version],
 	[  --with-build-version=STR     : build version ],
 	[ BOOTH_BUILD_VERSION="$withval" ],
-	[ ])
+	[ BOOTH_BUILD_VERSION="$PACKAGE_VERSION" ])
 
 AC_ARG_ENABLE([resource-monitor],
 	[  --enable-resource-monitor       : Enabling Resource Monitor ],


### PR DESCRIPTION
Since it became an error at the time of configure, it changed so that PACKAGE_VERSION might be used for an initial value.

```
# ./configure --with-build-version="1.0"
(snip)
configure: Sanitizing exec_prefix: NONE
./configure: line 10217: syntax error near unexpected token `fi'
./configure: line 10217: `fi'
```
