### PR TITLE
added basic redhat <7.0 init scripts

### DIFF
--- a/script/redhat/booth-arbitrator.init
+++ b/script/redhat/booth-arbitrator.init
@@ -1,0 +1,110 @@
+#!/bin/sh
+#
+# booth-arbitrator The Booth Cluster Ticket Manager
+#
+# chkconfig:  2345 64 36
+# description: Booth manages tickets which authorize cluster sites located in \
+#              geographically dispersed locations to run resources. It \
+#              facilitates support of geographically distributed clustering in \
+#              Pacemaker. URL: https://github.com/ClusterLabs/booth
+
+### BEGIN INIT INFO
+# Provides: booth-arbitrator
+# Required-Start: $network
+# Required-Stop: $network
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: The Booth Cluster Ticket Manager
+# Description: Booth manages tickets which authorize cluster sites located in \
+#              geographically dispersed locations to run resources. It \
+#              facilitates support of geographically distributed clustering in \
+#              Pacemaker. URL: https://github.com/ClusterLabs/booth
+### END INIT INFO
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+exec="/usr/sbin/boothd"
+prog="boothd"
+config="/etc/booth/booth.conf"
+
+[ -e /etc/sysconfig/booth-arbitrator ] && . /etc/sysconfig/booth-arbitrator
+
+lockfile=/var/lock/subsys/$prog
+
+start() {
+    [ -x $exec ] || exit 5
+    [ -f $config ] || exit 6
+    echo -n $"Starting $prog: "
+    # if not running, start it up here, usually something like "daemon $exec"
+    daemon "$exec daemon -c $config"
+    retval=$?
+    echo 
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    # stop it here, often "killproc $prog"
+    killproc $prog
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+reload() {
+    restart
+}
+
+force_reload() {
+    restart
+}
+
+rh_status() {
+    # run checks to determine if the service is running or use generic status
+    status $prog
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    reload)
+        rh_status_q || exit 7
+        $1
+        ;;
+    force-reload)
+        force_reload
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload|force-reload}"
+        exit 2
+esac
+exit $?

--- a/script/redhat/booth-arbitrator.sysconfig
+++ b/script/redhat/booth-arbitrator.sysconfig
@@ -1,0 +1,3 @@
+# Booth configuration file to load
+config="/etc/booth/booth.conf"
+


### PR DESCRIPTION
The current lsb init script and systemd config doesn't really work well with RHEL 6.*(5), so I created one myself.

Because of time constraints, I did not update the RPM package to properly provide this redhat initscript yet.
