### PR TITLE
low:fix:remove unnecessary return from unit-test.py

### DIFF
--- a/script/unit-test.py
+++ b/script/unit-test.py
@@ -80,7 +80,6 @@ class UT():
 # {{{ setup functions
     @classmethod
     def _filename(cls, desc):
-        return "/tmp/booth-unittest.%s" % desc
         return "/tmp/booth-unittest.%d.%s" % (os.getpid(), desc)
 
 


### PR DESCRIPTION
In function _filename of class UT, there are two returns, and the
second one will never be executed. Remove one line of return in the
fix.