### PR TITLE
typo fix: there is no %{S:2} defined in booth.spec

### DIFF
--- a/booth.spec
+++ b/booth.spec
@@ -137,7 +137,8 @@ rm -f %{buildroot}/%{test_path}/test/*.pyc
 %if 0%{?suse_version}
 #SUSE firewall rule
 mkdir -p $RPM_BUILD_ROOT/%{_fwdefdir}
-install -m 644 %{S:2} $RPM_BUILD_ROOT/%{_fwdefdir}/booth
+install -m 644 contrib/geo-cluster.fwd $RPM_BUILD_ROOT/%{_fwdefdir}/booth
+#install -m 644 %{S:2} $RPM_BUILD_ROOT/%{_fwdefdir}/booth
 %endif
 
 %check


### PR DESCRIPTION
In line 140 of booth.spec, there is "install -m 644 %{S:2}", but
when build booth on SLE12 or openSUSE Leap42.1, it reports %{SOURCE2}
is not defined. I guess the file should be contrib/geo-cluster.fwd.
This patch can fix the build error.