### PR TITLE
Add filter to get most matched site or arbitrator

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -88,7 +88,7 @@ static int find_address(unsigned char ipaddr[BOOTH_IPADDR_LEN],
 	int bytes, bits_left, mask;
 	unsigned char node_bits, ip_bits;
 	uint8_t *n_a;
-	int matched;
+	int matched, matched_tmp = 0;
 	enum match_type did_match = NO_MATCH;
 
 
@@ -108,10 +108,13 @@ static int find_address(unsigned char ipaddr[BOOTH_IPADDR_LEN],
 				break;
 
 		if (matched == node->addrlen) {
-			*address_bits_matched = matched * 8;
-			*me = node;
-			did_match = EXACT_MATCH;
-			break;
+			if((matched_tmp < matched * 8)||((node->type == SITE)&&(matched_tmp == matched * 8)))
+			{
+				*address_bits_matched = matched_tmp = matched * 8;
+				*me = node;
+				did_match = EXACT_MATCH;
+				continue;
+			}
 		}
 
 		if (!fuzzy_allowed)


### PR DESCRIPTION
By design, arbitrator can not revoke tickets, and if the
commandline does not specify a site, it will try to find a "local site"
which has the same subnet with the machine that runs booth command.

If arbitrator and all sites are in the same subnet, booth will choose
the first one as "local site". Booth might think it is an arbitrator,
and will not execute revoke operations.

This patch add a filter to get most matched arbitrator/booth.