### PR TITLE
CI: travis: workaround 127.0.1.1 not assigned with loopback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,15 @@ env:
         - GLUE=0
 
 before_install:
+        # following command is so as to counterweight unfortunate change
+        # https://github.com/travis-ci/travis-cookbooks/commit/6c575d5d55c08e3a0c046dc7de2aa5d5b38e0b63
+        # that made proper hostnames be mapped from 127.0.1.1 address
+        # rather than 127.0.0.1 (properly assigned to loopback interface),
+        # hence (likely) caused "hostname -i" return that other address
+        # that is normally not assigned to loopback (and hence booth
+        # cannot identify "itself" within configured sites, leading to
+        # spurious test suite failure) so do that manually as a workaround
+        - sudo ip addr add 127.0.1.1/8 scope host dev lo
         - sudo apt-get update -qq
         - sudo apt-get install -qq -y libglib2.0-dev libcrmcluster4-dev
         - test "${GLUE}" = 0


### PR DESCRIPTION
This is so as to counterweight unfortunate change
https://github.com/travis-ci/travis-cookbooks/commit/6c575d5d55c08e3a0c046dc7de2aa5d5b38e0b63
that made proper hostnames be mapped from 127.0.1.1 address rather than
127.0.0.1 (properly assigned to loopback interface), hence (likely)
caused "hostname -i" return that other address that is normally not
assigned to loopback (and hence booth cannot identify "itself" within
configured sites, leading to spurious test suite failure).