### PR TITLE
Build: create and set working directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -83,6 +83,10 @@ install-exec-local:
 	$(INSTALL) -d $(DESTDIR)/${boothsitedir}
 	$(INSTALL) -d $(DESTDIR)/${boothocfdir}
 	$(INSTALL) -d $(DESTDIR)/${SOCKETDIR}
+	$(INSTALL) -d $(DESTDIR)/${BOOTH_LIB_DIR} -m 750
+	-chown $(CRM_DAEMON_USER):$(CRM_DAEMON_GROUP) $(DESTDIR)/${BOOTH_LIB_DIR} 
+	$(INSTALL) -d $(DESTDIR)/${BOOTH_CORE_DIR} -m 750
+	-chown $(CRM_DAEMON_USER):$(CRM_DAEMON_GROUP) $(DESTDIR)/${BOOTH_CORE_DIR}
 
 install-exec-hook:
 	ln -sf ${sbindir}/boothd $(DESTDIR)/${sbindir}/booth
@@ -93,6 +97,8 @@ uninstall-local:
 	rmdir $(DESTDIR)/${bootharbitratordir} || :;
 	rmdir $(DESTDIR)/${boothsitedir} || :;
 	rmdir $(DESTDIR)/${SOCKETDIR} || :;
+	rmdir $(DESTDIR)/${BOOTH_CORE_DIR} || :;
+	rmdir $(DESTDIR)/${BOOTH_LIB_DIR} || :;
 
 test: check
 

--- a/booth.spec
+++ b/booth.spec
@@ -166,8 +166,8 @@ echo "%%run_build_tests set to %run_build_tests; skipping tests"
 %dir /usr/lib/ocf/lib
 %dir /usr/lib/ocf/lib/booth
 %dir %{_sysconfdir}/booth
-%dir %{_var}/lib/booth
-%dir %{_var}/lib/booth/cores
+%dir %attr (750, %{uname}, %{gname}) %{_var}/lib/booth/
+%dir %attr (750, %{uname}, %{gname}) %{_var}/lib/booth/cores
 %{_sbindir}/rcbooth-arbitrator
 /usr/lib/ocf/resource.d/pacemaker/booth-site
 /usr/lib/ocf/lib/booth/geo_attr.sh

--- a/booth.spec
+++ b/booth.spec
@@ -166,6 +166,8 @@ echo "%%run_build_tests set to %run_build_tests; skipping tests"
 %dir /usr/lib/ocf/lib
 %dir /usr/lib/ocf/lib/booth
 %dir %{_sysconfdir}/booth
+%dir %{_var}/lib/booth
+%dir %{_var}/lib/booth/cores
 %{_sbindir}/rcbooth-arbitrator
 /usr/lib/ocf/resource.d/pacemaker/booth-site
 /usr/lib/ocf/lib/booth/geo_attr.sh

--- a/configure.ac
+++ b/configure.ac
@@ -169,6 +169,31 @@ cc_supports_flag() {
          return $RC
 }
 
+## extract header or define
+try_extract_header_define() {
+	  AC_MSG_CHECKING(if $2 in $1 exists)
+	  Cfile=$srcdir/extract_define.$2.${$}
+	  printf "#include <stdio.h>\n" > ${Cfile}.c
+	  printf "#include <%s>\n" $1 >> ${Cfile}.c
+	  printf "int main(int argc, char **argv) {\n" >> ${Cfile}.c
+	  printf "#ifdef %s\n" $2 >> ${Cfile}.c
+	  printf "printf(\"%%s\", %s);\n" $2 >> ${Cfile}.c
+	  printf "#endif \n return 0; }\n" >> ${Cfile}.c
+	  $CC $CFLAGS ${Cfile}.c -o ${Cfile} 2>/dev/null
+	  value=
+	  if test -x ${Cfile}; then
+	      value=`${Cfile} 2>/dev/null`
+	  fi
+	  if  test x"${value}" == x""; then
+	      value=$3
+	      AC_MSG_RESULT(default: $value)
+	  else
+	      AC_MSG_RESULT($value)
+	  fi
+	  printf $value
+	  rm -rf ${Cfile}.c ${Cfile} ${Cfile}.dSYM ${Cfile}.gcno
+	}
+
 ## cleanup
 AC_MSG_NOTICE(Sanitizing prefix: ${prefix})
 case $prefix in
@@ -315,6 +340,15 @@ if test "x$coredump_nursing" != "xno"; then
 	AC_DEFINE(COREDUMP_NURSING, [], [eligible for coredump nursing])
 fi
 AM_CONDITIONAL([COREDUMP_NURSING], [test "x$coredump_nursing" != "xno"])
+
+# define CRM daemon user & group
+CRM_DAEMON_USER=`try_extract_header_define glue_config.h HA_CCMUSER hacluster`
+AC_DEFINE_UNQUOTED(CRM_DAEMON_USER,"$CRM_DAEMON_USER", User to run Booth daemon as)
+AC_SUBST(CRM_DAEMON_USER)
+
+CRM_DAEMON_GROUP=`try_extract_header_define glue_config.h HA_APIGROUP haclient`
+AC_DEFINE_UNQUOTED(CRM_DAEMON_GROUP,"$CRM_DAEMON_GROUP", Group to run Booth daemon as)
+AC_SUBST(CRM_DAEMON_GROUP)
 
 # OS detection
 # THIS SECTION MUST DIE!
@@ -515,11 +549,19 @@ AC_SUBST([LINT_FLAGS])
 
 AC_DEFINE_UNQUOTED([SOCKETDIR], "$(eval echo ${SOCKETDIR})", [Socket directory])
 
+BOOTH_LIB_DIR=${localstatedir}/lib/booth
+BOOTH_CORE_DIR=${localstatedir}/lib/booth/cores
 BOOTHSYSCONFDIR=${sysconfdir}/booth
+
 AC_SUBST([HAVE_LOG_CIB_DIFF])
 AC_SUBST([HAVE_XML_LOG_PATCHSET])
+AC_SUBST([BOOTH_LIB_DIR])
+AC_SUBST([BOOTH_CORE_DIR])
 AC_SUBST([BOOTHSYSCONFDIR])
 AC_SUBST([BOOTH_BUILD_VERSION])
+
+AC_DEFINE_UNQUOTED([BOOTH_LIB_DIR], "$(eval echo ${BOOTH_LIB_DIR})", [booth lib directory])
+AC_DEFINE_UNQUOTED([BOOTH_CORE_DIR], "$(eval echo ${BOOTH_CORE_DIR})", [booth working directory])
 AC_DEFINE_UNQUOTED([BOOTHSYSCONFDIR], "$(eval echo ${BOOTHSYSCONFDIR})", [booth config directory])
 
 AC_DEFINE_UNQUOTED([PACKAGE_FEATURES], "${PACKAGE_FEATURES}", [booth built-in features])
@@ -548,6 +590,9 @@ AC_MSG_RESULT([  Logging provider         = ${logging_provider}])
 AC_MSG_RESULT([  Range2random provider    = ${range2random_provider}])
 AC_MSG_RESULT([  Nametag provider         = ${nametag_provider}])
 AC_MSG_RESULT([  Coredump nursing         = ${coredump_nursing}])
+AC_MSG_RESULT([  Working directory        = ${BOOTH_CORE_DIR}])
+AC_MSG_RESULT([  HA group name            = ${CRM_DAEMON_GROUP}])
+AC_MSG_RESULT([  HA user name             = ${CRM_DAEMON_USER}])
 AC_MSG_RESULT([])
 AC_MSG_RESULT([$PACKAGE build info:])
 AC_MSG_RESULT([  Library SONAME           = ${SONAME}])

--- a/src/main.c
+++ b/src/main.c
@@ -1480,8 +1480,6 @@ static int do_server(int type)
 #else
 	if (chdir(BOOTH_CORE_DIR) < 0) {
 		log_error("cannot change working directory to %s", BOOTH_CORE_DIR);
-	} else {
-		log_info("booth working directory set to %s", BOOTH_CORE_DIR);
 	}
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -1477,6 +1477,12 @@ static int do_server(int type)
 	}
 	cl_cdtocoredir();
 	prctl(PR_SET_DUMPABLE, (unsigned long)TRUE, 0UL, 0UL, 0UL);
+#else
+	if (chdir(BOOTH_CORE_DIR) < 0) {
+		log_error("cannot change working directory to %s", BOOTH_CORE_DIR);
+	} else {
+		log_info("booth working directory set to %s", BOOTH_CORE_DIR);
+	}
 #endif
 
 	signal(SIGCHLD, (__sighandler_t)wait_child);


### PR DESCRIPTION
At present, booth doesn't set the working directory itself. If it is linked with cluster-glue, the working directory is changed by cluster-glue. Otherwise, if we use libqb, nothing takes care of that. As a result, we have problems with creating temporary files and core dumps.
The changes in this pull request are about creating the active directory /var/lib/booth/cores during installation and setting it during startup, if the application is not linked with cluster-glue.