### PR TITLE
Fix GCC-7 warning on buffer size

### DIFF
--- a/src/ticket.c
+++ b/src/ticket.c
@@ -460,7 +460,7 @@ static void log_reacquire_reason(struct ticket_config *tk)
 {
 	int valid;
 	const char *where_granted = "\0";
-	char buff[64];
+	char buff[75];
 
 	valid = is_time_set(&tk->term_expires) && !is_past(&tk->term_expires);
 


### PR DESCRIPTION
Warning produced with GCC 7.1.0:

```
ticket.c: In function ‘process_tickets’:
ticket.c:470:44: warning: ‘%s’ directive output may be truncated writing up to 63 bytes into a region of size 53 [-Wformat-truncation=]
   snprintf(buff, sizeof(buff), "granted to %s",
                                            ^~
ticket.c:470:3: note: ‘snprintf’ output between 12 and 75 bytes into a destination of size 64
   snprintf(buff, sizeof(buff), "granted to %s",
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    site_string(tk->leader));
    ~~~~~~~~~~~~~~~~~~~~~~~~
```