### PR TITLE
Booth Daemon Arguments: disable foreground for D flag

### DIFF
--- a/docs/boothd.8.txt
+++ b/docs/boothd.8.txt
@@ -97,12 +97,11 @@ The configuration name also determines the name of the PID file - for the defaul
 	Report version information.
 
 *-S*::
-	'systemd' mode: don't fork. This is like '-D' but without the debug output.
+	'systemd' mode: don't fork.
+	Disables daemonizing, the process will remain in the foreground.
 
 *-D*::
-	Debug output/don't daemonize.
-	Increases the debug output level; booth daemon remains
-	in the foreground.
+	Increases the debug output level.
 
 *-l* 'lockfile'::
 	Use another lock file. By default, the lock file name is

--- a/src/main.c
+++ b/src/main.c
@@ -1116,10 +1116,12 @@ static int read_arguments(int argc, char **argv)
 					strcat(cp, BOOTH_DEFAULT_CONF_EXT);
 			}
 			break;
+
 		case 'D':
 			debug_level++;
 			enable_stderr = 1;
-			/* Fall through */
+			break;
+
 		case 'S':
 			daemonize = 0;
 			break;

--- a/src/main.c
+++ b/src/main.c
@@ -1124,6 +1124,7 @@ static int read_arguments(int argc, char **argv)
 
 		case 'S':
 			daemonize = 0;
+			enable_stderr = 1;
 			break;
 
 		case 'l':

--- a/test/boothrunner.py
+++ b/test/boothrunner.py
@@ -31,6 +31,9 @@ class BoothRunner:
     def set_debug(self):
         self.args += [ '-D' ]
 
+    def set_foreground(self):
+        self.args += [ '-S' ]
+
     def all_args(self):
         return [ self.boothd_path ] + self.args + self.final_args
 

--- a/test/serverenv.py
+++ b/test/serverenv.py
@@ -33,7 +33,7 @@ ticket="ticketB"
 
     def run_booth(self, expected_exitcode, expected_daemon,
                   config_text=None, config_file=None, lock_file=True,
-                  args=[], debug=False):
+                  args=[], debug=False, foreground=False):
         '''
         Runs boothd.  Defaults to using a temporary lock file and the
         standard config file path.  There are four possible types of
@@ -42,7 +42,7 @@ ticket="ticketB"
             - boothd exits non-zero without launching a daemon (setup phase failed,
               e.g. due to invalid configuration file)
             - boothd exits zero after launching a daemon (successful operation)
-            - boothd does not exit (running in foreground / debug mode)
+            - boothd does not exit (running in foreground mode)
             - boothd does not exit (setup phase hangs, e.g. while attempting
               to connect to peer during ticket_catchup())
 
@@ -61,13 +61,15 @@ ticket="ticketB"
                 an integer, or False if booth is not expected to terminate
                 within the timeout
             expected_daemon
-                True iff a daemon is expected to be launched (this includes
-                running the server in debug / foreground mode via -D; even
-                though in this case the server's not technically not a daemon,
+                True iff a daemon is expected to be launched (this means
+                running the server in foreground mode via -S;
+                even though in this case the server's not technically not a daemon,
                 we still want to treat it like one by checking the lockfile
                 before and after we kill it)
             debug
                 True means pass the -D parameter
+            foreground
+                True means pass the -S parameter
 
         Returns a (pid, return_code, stdout, stderr, runner) tuple,
         where return_code/stdout/stderr are None iff pid is still running.
@@ -96,6 +98,9 @@ ticket="ticketB"
 
         if debug:
             runner.set_debug()
+
+        if foreground:
+            runner.set_foreground()
 
         runner.show_args()
         (pid, return_code, stdout, stderr) = runner.run()

--- a/test/servertests.py
+++ b/test/servertests.py
@@ -86,6 +86,16 @@ class ServerTests(ServerTestEnvironment):
     def test_debug_mode(self):
         (pid, ret, stdout, stderr, runner) = \
             self.run_booth(config_text=self.working_config, debug=True,
+                           expected_exitcode=0, expected_daemon=True)
+
+    def test_foreground_mode(self):
+        (pid, ret, stdout, stderr, runner) = \
+            self.run_booth(config_text=self.working_config, foreground=True,
+                           expected_exitcode=None, expected_daemon=True)
+
+    def test_debug_and_foreground_mode(self):
+        (pid, ret, stdout, stderr, runner) = \
+            self.run_booth(config_text=self.working_config, debug=True, foreground=True,
                            expected_exitcode=None, expected_daemon=True)
 
     def test_missing_transport(self):


### PR DESCRIPTION
As discussed in [Issue 61](https://github.com/ClusterLabs/booth/issues/61), this change will disable moving Booth to foreground, when debug output is enabled.
We need this change to allow using debug mode in Booth instances acting as HA resources.