### PR TITLE
Disable stderr for daemon mode

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1119,7 +1119,6 @@ static int read_arguments(int argc, char **argv)
 
 		case 'D':
 			debug_level++;
-			enable_stderr = 1;
 			break;
 
 		case 'S':


### PR DESCRIPTION
As advised in a [previous pull request](https://github.com/ClusterLabs/booth/pull/62), I removed stderr flag from daemon mode.