### PR TITLE
Fix asciidoc build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,8 +65,8 @@ AC_PATH_PROGS(ASCIIDOCTOR, asciidoctor)
 AC_PATH_PROGS(A2X, a2x)
 AC_PATH_PROGS(XML2CONFIG, xml2-config)
 
-AM_CONDITIONAL(IS_ASCIIDOC, test "x{ASCIIDOC}" = "xasciidoc")
-AM_CONDITIONAL(IS_A2X, test "x${A2X}" = "xa2x")
+AM_CONDITIONAL(IS_ASCIIDOC, test x"${ASCIIDOC}" != x"")
+AM_CONDITIONAL(IS_A2X, test x"${A2X}" != x"")
 AM_CONDITIONAL(BUILD_ASCIIDOC, test x"${A2X}" != x"" || test x"${ASCIIDOCTOR}" != x"")
 AM_CONDITIONAL(BUILD_ASCIIDOC_HTML_MAN,
 	       (test "x${ASCIIDOC}" != "x" || test x"${ASCIIDOCTOR}" != x"") && test "x$with_html_man" = "xyes")


### PR DESCRIPTION
After the last commits, booth has been failing to build for me when asciidoctor was not present.
The line "MANPAGE_GENERATOR += $(ASCIIDOCTOR) -b manpage" was trying to be executed, but with no asciidoctor present on my machine.
I changed the comparisons in configure.ac, to detect a2x and asciidoc in the same way as for other variables, and it works fine now.