### PR TITLE
docs: fix an oversight in Makefile.am, stop gitignoring a tracked file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,8 @@ tools/booth_resource_monitord
 
 *.pyc
 
-docs/boothd.8*
+/docs/boothd.8*
+!/docs/boothd.8.txt
 
 doxygen
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -37,9 +37,9 @@ man8_MANS	= $(generated_mans)
 endif
 
 if IS_ASCIIDOC
-HTML_GENERATOR += $(ASCIIDOC)--unsafe --backend=xhtml11
+HTML_GENERATOR += $(ASCIIDOC) --unsafe --backend=xhtml11
 else
-HTML_GENERATOR += $(ASCIIDOCTOR)-b xhtml5
+HTML_GENERATOR += $(ASCIIDOCTOR) -b xhtml5
 endif
 
 if IS_A2X


### PR DESCRIPTION
The former was introduced with Asciidoctor support introduction
(c40e3b0a), the latter was mistaken from beginning (5a53018a), but
it didn't matter since docs/boothd.8.txt had already been tracked
by then -- where it may matter, though, are operations like diff'ing.

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>