### PR TITLE
docs: boothd.8: fix runaway formatting for what's config file snippet

### DIFF
--- a/docs/boothd.8.txt
+++ b/docs/boothd.8.txt
@@ -560,10 +560,12 @@ performed for manual tickets.
 Manual tickets are defined in a configuration files by adding a 'mode'
 ticket parameter and setting it to 'manual' or 'MANUAL':
 
+-----------------------
 ticket="manual-ticket"
     [...]
     mode = manual
     [...]
+-----------------------
 
 Manual tickets can be granted and revoked by using normal 'grant' and
 'revoke' commands, with the usual flags and parameters. The only


### PR DESCRIPTION
This was (likely) exposed with asciidoctor being updated to v2.0.0+
resulting in this "visual" (as in actually viewing the man page) diff
before vs. after:

> -       ticket="manual-ticket"
> -           [...]
> -           mode = manual
> -           [...]
> +       ticket="manual-ticket" [...] mode = manual [...]

Marking that part as a literal block (in an established manner)
restores the sanity.

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>