### PR TITLE
Maintenance swipe: get rid of some global variables in favour of actual data flow visibility

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,11 +7,13 @@ AM_CPPFLAGS		= -I$(top_builddir)/include
 
 sbin_PROGRAMS		= boothd
 
-boothd_SOURCES	 	= config.c main.c raft.c ticket.c  transport.c \
-			  pacemaker.c handler.c request.c attr.c manual.c
+boothd_SOURCES	 	= attr.c config.c handler.c main.c \
+			  manual.c pacemaker.c raft.c request.c \
+			  ticket.c transport.c utils.c
 
-noinst_HEADERS		= booth.h pacemaker.h \
-			  config.h log.h raft.h ticket.h transport.h handler.h request.h attr.h manual.h
+noinst_HEADERS		= attr.h booth.h config.h handler.h log.h \
+			  manual.h pacemaker.h raft.h request.h \
+			  ticket.h transport.h utils.h
 
 if BUILD_TIMER_C
 boothd_SOURCES += timer.c

--- a/src/alt/nametag_libsystemd.c
+++ b/src/alt/nametag_libsystemd.c
@@ -43,14 +43,17 @@ void sd_notify_wrapper(const char *fmt, ...)
 	char buffer[255];
 	char *fmt_iter;
 	char *suffix = NULL;
-	va_list ap;
+	va_list ap, copy;
 
-	switch (local->type) {
-		case ARBITRATOR:
-		case GEOSTORE:
-			break;
-		default:
-			return;  /* not expected to be run as system service */
+	/* this code undoes the type_to_string mapping */
+	va_start(ap, fmt);
+	va_copy(copy, ap);
+	for (int i = 0; i < 3; i++) {
+		fmt_iter = va_arg(copy, char *);
+	}
+	/* see config.c:type_to_string */
+	if (strcmp(fmt_iter, "arbitrator") && strcmp(fmt_iter, "attr")) {
+		return;  /* not expected to be run as system service */
 	}
 
 	fmt_iter = strchr(fmt, '%');
@@ -67,7 +70,6 @@ void sd_notify_wrapper(const char *fmt, ...)
 	}
 	while (isspace(*++suffix)) /* noop */ ;
 
-	va_start(ap, fmt);
 	fmt_iter = va_arg(ap, char *);  /* just shift by one */
 	assert(!strcmp(fmt_iter, DAEMON_NAME));
 	rv = vsnprintf(buffer, sizeof(buffer), suffix, ap);

--- a/src/attr.c
+++ b/src/attr.c
@@ -290,22 +290,31 @@ int store_geo_attr(struct ticket_config *tk, const char *name,
 	return 0;
 }
 
-static cmd_result_t attr_set(struct ticket_config *tk, struct boothc_attr_msg *msg)
+static cmd_result_t attr_set(struct booth_config *conf_ptr,
+                             struct ticket_config *tk,
+                             struct boothc_attr_msg *msg)
 {
 	int rc;
+
+	assert(conf_ptr != NULL);
 
 	rc = store_geo_attr(tk, msg->attr.name, msg->attr.val, 0);
 	if (rc) {
 		return RLT_SYNC_FAIL;
 	}
-	(void)pcmk_handler.set_attr(tk, msg->attr.name, msg->attr.val);
+	(void) conf_ptr->ticket_handler->set_attr(tk, msg->attr.name,
+	                                          msg->attr.val);
 	return RLT_SUCCESS;
 }
 
-static cmd_result_t attr_del(struct ticket_config *tk, struct boothc_attr_msg *msg)
+static cmd_result_t attr_del(struct booth_config *conf_ptr,
+                             struct ticket_config *tk,
+                             struct boothc_attr_msg *msg)
 {
 	gboolean rv;
 	gpointer orig_key, value;
+
+	assert(conf_ptr != NULL);
 
 	/*
 	 * lookup attr
@@ -322,7 +331,7 @@ static cmd_result_t attr_del(struct ticket_config *tk, struct boothc_attr_msg *m
 
 	rv = g_hash_table_remove(tk->attr, msg->attr.name);
 
-	(void)pcmk_handler.del_attr(tk, msg->attr.name);
+	(void) conf_ptr->ticket_handler->del_attr(tk, msg->attr.name);
 
 	return gbool2rlt(rv);
 }
@@ -438,10 +447,10 @@ int process_attr_request(struct booth_config *conf_ptr,
 			goto reply_now;
 		return 1;
 	case ATTR_SET:
-		rv = attr_set(tk, msg);
+		rv = attr_set(conf_ptr, tk, msg);
 		break;
 	case ATTR_DEL:
-		rv = attr_del(tk, msg);
+		rv = attr_del(conf_ptr, tk, msg);
 		break;
 	}
 

--- a/src/attr.c
+++ b/src/attr.c
@@ -184,7 +184,7 @@ int do_attr_command(struct booth_config *conf_ptr, cmd_request_t cmd)
 	if (rv < 0)
 		goto out_close;
 
-	rv = tpt->send(site, &cl.attr_msg, sendmsglen(&cl.attr_msg));
+	rv = tpt->send(conf_ptr, site, &cl.attr_msg, sendmsglen(&cl.attr_msg));
 	if (rv < 0)
 		goto out_close;
 
@@ -346,7 +346,9 @@ append_attr(gpointer key, gpointer value, gpointer user_data)
 }
 
 
-static cmd_result_t attr_get(struct ticket_config *tk, int fd, struct boothc_attr_msg *msg)
+static cmd_result_t attr_get(struct booth_config *conf_ptr,
+                             struct ticket_config *tk, int fd,
+                             struct boothc_attr_msg *msg)
 {
 	cmd_result_t rv = RLT_SUCCESS;
 	struct boothc_hdr_msg hdr;
@@ -369,14 +371,16 @@ static cmd_result_t attr_get(struct ticket_config *tk, int fd, struct boothc_att
 	g_string_printf(attr_val, "%s\n", a->val);
 	init_header(&hdr.header, ATTR_GET, 0, 0, RLT_SUCCESS, 0,
 		sizeof(hdr) + attr_val->len);
-	if (send_header_plus(fd, &hdr, attr_val->str, attr_val->len))
+	if (send_header_plus(conf_ptr, fd, &hdr, attr_val->str, attr_val->len))
 		rv = RLT_SYNC_FAIL;
 	if (attr_val)
 		g_string_free(attr_val, FALSE);
 	return rv;
 }
 
-static cmd_result_t attr_list(struct ticket_config *tk, int fd, struct boothc_attr_msg *msg)
+static cmd_result_t attr_list(struct booth_config *conf_ptr,
+                              struct ticket_config *tk, int fd,
+                              struct boothc_attr_msg *msg)
 {
 	GString *data;
 	cmd_result_t rv;
@@ -395,7 +399,7 @@ static cmd_result_t attr_list(struct ticket_config *tk, int fd, struct boothc_at
 
 	init_header(&hdr.header, ATTR_LIST, 0, 0, RLT_SUCCESS, 0,
 		sizeof(hdr) + data->len);
-	rv = send_header_plus(fd, &hdr, data->str, data->len);
+	rv = send_header_plus(conf_ptr, fd, &hdr, data->str, data->len);
 
 	if (data)
 		g_string_free(data, FALSE);
@@ -422,12 +426,12 @@ int process_attr_request(struct booth_config *conf_ptr,
 
 	switch (cmd) {
 	case ATTR_LIST:
-		rv = attr_list(tk, req_client->fd, msg);
+		rv = attr_list(conf_ptr, tk, req_client->fd, msg);
 		if (rv)
 			goto reply_now;
 		return 1;
 	case ATTR_GET:
-		rv = attr_get(tk, req_client->fd, msg);
+		rv = attr_get(conf_ptr, tk, req_client->fd, msg);
 		if (rv)
 			goto reply_now;
 		return 1;
@@ -441,7 +445,7 @@ int process_attr_request(struct booth_config *conf_ptr,
 
 reply_now:
 	init_header(&hdr.header, CL_RESULT, 0, 0, rv, 0, sizeof(hdr));
-	send_header_plus(req_client->fd, &hdr, NULL, 0);
+	send_header_plus(conf_ptr, req_client->fd, &hdr, NULL, 0);
 	return 1;
 }
 

--- a/src/attr.c
+++ b/src/attr.c
@@ -402,7 +402,8 @@ static cmd_result_t attr_list(struct ticket_config *tk, int fd, struct boothc_at
 	return rv;
 }
 
-int process_attr_request(struct client *req_client, void *buf)
+int process_attr_request(struct booth_config *conf_ptr,
+                         struct client *req_client, void *buf)
 {
 	cmd_result_t rv = RLT_SYNC_FAIL;
 	struct ticket_config *tk;
@@ -412,7 +413,7 @@ int process_attr_request(struct client *req_client, void *buf)
 
 	msg = (struct boothc_attr_msg *)buf;
 	cmd = ntohl(msg->header.cmd);
-	if (!check_ticket(msg->attr.tkt_id, &tk)) {
+	if (!check_ticket(conf_ptr, msg->attr.tkt_id, &tk)) {
 		log_warn("client referenced unknown ticket %s",
 				msg->attr.tkt_id);
 		rv = RLT_INVALID_ARG;
@@ -450,7 +451,8 @@ reply_now:
  * only clients retrieve/manage attributes and they connect
  * directly to the target site
  */
-int attr_recv(void *buf, struct booth_site *source)
+int attr_recv(struct booth_config *conf_ptr, void *buf,
+              struct booth_site *source)
 {
 	struct boothc_attr_msg *msg;
 	struct ticket_config *tk;
@@ -460,7 +462,7 @@ int attr_recv(void *buf, struct booth_site *source)
 	log_warn("unexpected attribute message from %s",
 			site_string(source));
 
-	if (!check_ticket(msg->attr.tkt_id, &tk)) {
+	if (!check_ticket(conf_ptr, msg->attr.tkt_id, &tk)) {
 		log_warn("got invalid ticket name %s from %s",
 				msg->attr.tkt_id, site_string(source));
 		source->invalid_cnt++;

--- a/src/attr.c
+++ b/src/attr.c
@@ -177,8 +177,8 @@ int do_attr_command(struct booth_config *conf_ptr, cmd_request_t cmd)
 
 	tpt = booth_transport + TCP;
 
-	init_header(&cl.attr_msg.header, cmd, 0, cl.options, 0, 0,
-		sizeof(cl.attr_msg));
+	init_header(conf_ptr, &cl.attr_msg.header, cmd, 0, cl.options, 0, 0,
+	            sizeof(cl.attr_msg));
 
 	rv = tpt->open(site);
 	if (rv < 0)
@@ -369,8 +369,8 @@ static cmd_result_t attr_get(struct booth_config *conf_ptr,
 		return RLT_SYNC_FAIL;
 	}
 	g_string_printf(attr_val, "%s\n", a->val);
-	init_header(&hdr.header, ATTR_GET, 0, 0, RLT_SUCCESS, 0,
-		sizeof(hdr) + attr_val->len);
+	init_header(conf_ptr, &hdr.header, ATTR_GET, 0, 0, RLT_SUCCESS, 0,
+	            sizeof(hdr) + attr_val->len);
 	if (send_header_plus(conf_ptr, fd, &hdr, attr_val->str, attr_val->len))
 		rv = RLT_SYNC_FAIL;
 	if (attr_val)
@@ -397,8 +397,8 @@ static cmd_result_t attr_list(struct booth_config *conf_ptr,
 	}
 	g_hash_table_foreach(tk->attr, append_attr, data);
 
-	init_header(&hdr.header, ATTR_LIST, 0, 0, RLT_SUCCESS, 0,
-		sizeof(hdr) + data->len);
+	init_header(conf_ptr, &hdr.header, ATTR_LIST, 0, 0, RLT_SUCCESS, 0,
+	            sizeof(hdr) + data->len);
 	rv = send_header_plus(conf_ptr, fd, &hdr, data->str, data->len);
 
 	if (data)
@@ -444,7 +444,7 @@ int process_attr_request(struct booth_config *conf_ptr,
 	}
 
 reply_now:
-	init_header(&hdr.header, CL_RESULT, 0, 0, rv, 0, sizeof(hdr));
+	init_header(conf_ptr, &hdr.header, CL_RESULT, 0, 0, rv, 0, sizeof(hdr));
 	send_header_plus(conf_ptr, req_client->fd, &hdr, NULL, 0);
 	return 1;
 }

--- a/src/attr.c
+++ b/src/attr.c
@@ -158,10 +158,11 @@ int do_attr_command(struct command_line *cl, struct booth_config *conf_ptr)
 	char *msg = NULL;
 
 	assert(conf_ptr != NULL && conf_ptr->transport != NULL);
+	assert(conf_ptr->local != NULL);
 	assert(cl != NULL);
 
 	if (*cl->site == '\0')
-		site = local;
+		site = conf_ptr->local;
 	else {
 		if (!find_site_by_name(conf_ptr, cl->site, &site, 1)) {
 			log_error("Site \"%s\" not configured.", cl->site);
@@ -170,7 +171,7 @@ int do_attr_command(struct command_line *cl, struct booth_config *conf_ptr)
 	}
 
 	if (site->type == ARBITRATOR) {
-		if (site == local) {
+		if (site == conf_ptr->local) {
 			log_error("We're just an arbitrator, no attributes here.");
 		} else {
 			log_error("%s is just an arbitrator, no attributes there.",

--- a/src/attr.c
+++ b/src/attr.c
@@ -210,7 +210,7 @@ int do_attr_command(struct booth_config *conf_ptr, cmd_request_t cmd)
 		goto out_close;
 	}
 
-	if (check_auth(site, msg, len)) {
+	if (check_auth(conf_ptr, site, msg, len)) {
 		log_error("%s failed to authenticate", site_string(site));
 		rv = -1;
 		goto out_close;

--- a/src/attr.c
+++ b/src/attr.c
@@ -157,6 +157,8 @@ int do_attr_command(struct booth_config *conf_ptr, cmd_request_t cmd)
 	int len, rv = -1;
 	char *msg = NULL;
 
+	assert(conf_ptr != NULL && conf_ptr->transport != NULL);
+
 	if (!*cl.site)
 		site = local;
 	else {
@@ -175,7 +177,7 @@ int do_attr_command(struct booth_config *conf_ptr, cmd_request_t cmd)
 		goto out_close;
 	}
 
-	tpt = booth_transport + TCP;
+	tpt = *conf_ptr->transport + TCP;
 
 	init_header(conf_ptr, &cl.attr_msg.header, cmd, 0, cl.options, 0, 0,
 	            sizeof(cl.attr_msg));

--- a/src/attr.c
+++ b/src/attr.c
@@ -149,7 +149,7 @@ static int read_server_reply(
 	return rv;
 }
 
-int do_attr_command(cmd_request_t cmd)
+int do_attr_command(struct booth_config *conf_ptr, cmd_request_t cmd)
 {
 	struct booth_site *site = NULL;
 	struct boothc_header *header;
@@ -160,7 +160,7 @@ int do_attr_command(cmd_request_t cmd)
 	if (!*cl.site)
 		site = local;
 	else {
-		if (!find_site_by_name(cl.site, &site, 1)) {
+		if (!find_site_by_name(conf_ptr, cl.site, &site, 1)) {
 			log_error("Site \"%s\" not configured.", cl.site);
 			goto out_close;
 		}

--- a/src/attr.h
+++ b/src/attr.h
@@ -43,8 +43,32 @@ int test_attr_reply(cmd_result_t reply_code, cmd_request_t cmd);
  */
 int do_attr_command(struct booth_config *conf_ptr, cmd_request_t cmd);
 
-int process_attr_request(struct client *req_client, void *buf);
-int attr_recv(void *buf, struct booth_site *source);
+/**
+ * @internal
+ * Facade to handle geostore related operations
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] req_client client structure of the sender
+ * @param[in] buf message itself
+ *
+ * @return 1 or see #attr_list, #attr_get, #attr_set, #attr_del
+ */
+int process_attr_request(struct booth_config *conf_ptr,
+                         struct client *req_client, void *buf);
+
+/**
+ * @internal
+ * Second stage of incoming datagram handling (after authentication)
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] buf message itself
+ * @param[in] source site structure of the sender
+ *
+ * @return -1 on error, 0 otherwise
+ */
+int attr_recv(struct booth_config *conf_ptr, void *buf,
+              struct booth_site *source);
+
 int store_geo_attr(struct ticket_config *tk, const char *name, const char *val, int notime);
 
 #endif /* _ATTR_H */

--- a/src/attr.h
+++ b/src/attr.h
@@ -30,18 +30,28 @@
 #include <glib.h>
 
 void print_geostore_usage(void);
-int test_attr_reply(cmd_result_t reply_code, cmd_request_t cmd);
+
+/**
+ * @internal
+ * Late handling of the response towards the client
+ *
+ * @param[in] cl parsed command line form
+ * @param[in] reply_code what the inner handling returns
+ *
+ * @return 0 on success, -1 on failure, 1 when "cannot serve"
+ */
+int test_attr_reply(struct command_line *cl, cmd_result_t reply_code);
 
 /**
  * @internal
  * Carry out a geo-atribute related command
  *
+ * @param[in] cl parsed command line structure
  * @param[inout] conf_ptr config object to refer to
- * @param[in] cmd what to perform
  *
  * @return 0 or negative value (-1 or -errno) on error
  */
-int do_attr_command(struct booth_config *conf_ptr, cmd_request_t cmd);
+int do_attr_command(struct command_line *cl, struct booth_config *conf_ptr);
 
 /**
  * @internal

--- a/src/attr.h
+++ b/src/attr.h
@@ -31,7 +31,18 @@
 
 void print_geostore_usage(void);
 int test_attr_reply(cmd_result_t reply_code, cmd_request_t cmd);
-int do_attr_command(cmd_request_t cmd);
+
+/**
+ * @internal
+ * Carry out a geo-atribute related command
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] cmd what to perform
+ *
+ * @return 0 or negative value (-1 or -errno) on error
+ */
+int do_attr_command(struct booth_config *conf_ptr, cmd_request_t cmd);
+
 int process_attr_request(struct client *req_client, void *buf);
 int attr_recv(void *buf, struct booth_site *source);
 int store_geo_attr(struct ticket_config *tk, const char *name, const char *val, int notime);

--- a/src/booth.h
+++ b/src/booth.h
@@ -361,7 +361,20 @@ int client_add(int fd, const struct booth_transport *tpt,
                void (*deadfn)(int ci));
 
 int find_client_by_fd(int fd);
-void safe_copy(char *dest, char *value, size_t buflen, const char *description);
+
+/**
+ * @internal
+ * Like strncpy, but with explicit protection and better diagnostics
+ *
+ * @param[out] dest where to copy the string to
+ * @param[in] value where to copy the string from
+ * @param[in] buflen nmaximum size of #dest (incl. trailing '\0', or sizeof)
+ * @param[in] description how to refer to the target as
+ *
+ * @return number of clients tracked (incl. this one)
+ */
+void safe_copy(char *dest, const char *value, size_t buflen,
+               const char *description);
 
 /**
  * @internal
@@ -395,8 +408,6 @@ struct command_line {
 	struct boothc_ticket_msg msg;
 	struct boothc_attr_msg attr_msg;
 };
-extern struct command_line cl;
-
 
 
 /* http://gcc.gnu.org/onlinedocs/gcc/Typeof.html */

--- a/src/booth.h
+++ b/src/booth.h
@@ -28,6 +28,7 @@
 #include <glib.h>
 #include "timer.h"
 
+struct booth_config;
 
 #define BOOTH_RUN_DIR "/var/run/booth/"
 #define BOOTH_LOG_DIR "/var/log"
@@ -337,16 +338,28 @@ struct client {
 	const struct booth_transport *transport;
 	struct boothc_ticket_msg *msg;
 	int offset; /* bytes read so far into msg */
-	void (*workfn)(int);
+	void (*workfn)(struct booth_config *conf_ptr, int);
 	void (*deadfn)(int);
 };
 
 extern struct client *clients;
 extern struct pollfd *pollfds;
 
-
+/**
+ * @internal
+ * For an established-connection socket, finalize the handling callbacks
+ *
+ * @param[in] file descriptor of the respective client socket
+ * @param[inout] tpt precooked transport handling callbacks to finalize
+ * @param[in] workfn callback to process incoming messages
+ * @param[in] workfn callback to handle termination of the connection
+ *
+ * @return number of clients tracked (incl. this one)
+ */
 int client_add(int fd, const struct booth_transport *tpt,
-		void (*workfn)(int ci), void (*deadfn)(int ci));
+               void (*workfn)(struct booth_config *conf_ptr, int ci),
+               void (*deadfn)(int ci));
+
 int find_client_by_fd(int fd);
 void safe_copy(char *dest, char *value, size_t buflen, const char *description);
 int update_authkey(void);

--- a/src/booth.h
+++ b/src/booth.h
@@ -362,7 +362,18 @@ int client_add(int fd, const struct booth_transport *tpt,
 
 int find_client_by_fd(int fd);
 void safe_copy(char *dest, char *value, size_t buflen, const char *description);
-int update_authkey(void);
+
+/**
+ * @internal
+ * Re-read and reflect possibly new contents of the authentication key file
+ *
+ * @note XXX UNUSED
+ *
+ * @param[inout] conf_ptr config object to refer to
+ *
+ * @return 0 in case of success, -1 otherwise
+ */
+int update_authkey(struct booth_config *conf_ptr);
 
 /**
  * @internal

--- a/src/booth.h
+++ b/src/booth.h
@@ -363,8 +363,15 @@ int client_add(int fd, const struct booth_transport *tpt,
 int find_client_by_fd(int fd);
 void safe_copy(char *dest, char *value, size_t buflen, const char *description);
 int update_authkey(void);
-void list_peers(int fd);
 
+/**
+ * @internal
+ * Response to "get all servers we know about"
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] fd file descriptor of the socket to respond to
+ */
+void list_peers(struct booth_config *conf_ptr, int fd);
 
 struct command_line {
 	int type;		/* ACT_ */

--- a/src/booth.h
+++ b/src/booth.h
@@ -324,9 +324,6 @@ struct booth_site {
 	uint32_t last_usecs;
 } __attribute__((packed));
 
-
-
-extern struct booth_site *local;
 extern struct booth_site *const no_leader;
 
 /** @} */

--- a/src/booth.h
+++ b/src/booth.h
@@ -361,20 +361,6 @@ int find_client_by_fd(int fd);
 
 /**
  * @internal
- * Like strncpy, but with explicit protection and better diagnostics
- *
- * @param[out] dest where to copy the string to
- * @param[in] value where to copy the string from
- * @param[in] buflen nmaximum size of #dest (incl. trailing '\0', or sizeof)
- * @param[in] description how to refer to the target as
- *
- * @return number of clients tracked (incl. this one)
- */
-void safe_copy(char *dest, const char *value, size_t buflen,
-               const char *description);
-
-/**
- * @internal
  * Re-read and reflect possibly new contents of the authentication key file
  *
  * @note XXX UNUSED

--- a/src/config.c
+++ b/src/config.c
@@ -892,56 +892,52 @@ out:
 	return -1;
 }
 
-
-int check_config(int type)
+int check_config(struct booth_config *conf_ptr, int type)
 {
 	struct passwd *pw;
 	struct group *gr;
 	char *cp, *input;
 
-	if (!booth_conf)
+	if (conf_ptr == NULL)
 		return -1;
 
-
 	input = (type == ARBITRATOR)
-		? booth_conf->arb_user
-		: booth_conf->site_user;
+		? conf_ptr->arb_user
+		: conf_ptr->site_user;
 	if (!*input)
 		goto u_inval;
 	if (isdigit(input[0])) {
-		booth_conf->uid = strtol(input, &cp, 0);
+		conf_ptr->uid = strtol(input, &cp, 0);
 		if (*cp != 0) {
 u_inval:
 			log_error("User \"%s\" cannot be resolved into a UID.", input);
 			return ENOENT;
 		}
-	}
-	else {
+	} else {
 		pw = getpwnam(input);
 		if (!pw)
 			goto u_inval;
-		booth_conf->uid = pw->pw_uid;
+		conf_ptr->uid = pw->pw_uid;
 	}
 
 
 	input = (type == ARBITRATOR)
-		? booth_conf->arb_group
-		: booth_conf->site_group;
+		? conf_ptr->arb_group
+		: conf_ptr->site_group;
 	if (!*input)
 		goto g_inval;
 	if (isdigit(input[0])) {
-		booth_conf->gid = strtol(input, &cp, 0);
+		conf_ptr->gid = strtol(input, &cp, 0);
 		if (*cp != 0) {
 g_inval:
 			log_error("Group \"%s\" cannot be resolved into a UID.", input);
 			return ENOENT;
 		}
-	}
-	else {
+	} else {
 		gr = getgrnam(input);
 		if (!gr)
 			goto g_inval;
-		booth_conf->gid = gr->gr_gid;
+		conf_ptr->gid = gr->gr_gid;
 	}
 
 	return 0;

--- a/src/config.c
+++ b/src/config.c
@@ -31,9 +31,10 @@
 #include "b_config.h"
 #include "booth.h"
 #include "config.h"
+#include "log.h"
 #include "raft.h"
 #include "ticket.h"
-#include "log.h"
+#include "utils.h"
 
 static int ticket_size = 0;
 

--- a/src/config.c
+++ b/src/config.c
@@ -37,6 +37,14 @@
 
 static int ticket_size = 0;
 
+static const struct booth_site _no_leader = {
+	.addr_string = "none",
+	.site_id = NO_ONE,
+	.index = -1,
+};
+struct booth_site *const no_leader = (struct booth_site*) &_no_leader;
+
+
 static int ticket_realloc(struct booth_config *conf_ptr)
 {
 	const int added = 5;
@@ -958,8 +966,10 @@ static int get_other_site(struct booth_config *conf_ptr,
 	if (conf_ptr == NULL)
 		return 0;
 
+	assert(conf_ptr->local != NULL);
+
 	FOREACH_NODE(conf_ptr, i, n) {
-		if (n != local && n->type == SITE) {
+		if (n != conf_ptr->local && n->type == SITE) {
 			if (!*node) {
 				*node = n;
 			} else {

--- a/src/config.c
+++ b/src/config.c
@@ -943,18 +943,18 @@ g_inval:
 	return 0;
 }
 
-
-static int get_other_site(struct booth_site **node)
+static int get_other_site(struct booth_config *conf_ptr,
+                          struct booth_site **node)
 {
 	struct booth_site *n;
 	int i;
 
 	*node = NULL;
-	if (!booth_conf)
+	if (conf_ptr == NULL)
 		return 0;
 
-	for (i = 0; i < booth_conf->site_count; i++) {
-		n = booth_conf->site + i;
+	for (i = 0; i < conf_ptr->site_count; i++) {
+		n = conf_ptr->site + i;
 		if (n != local && n->type == SITE) {
 			if (!*node) {
 				*node = n;
@@ -967,20 +967,20 @@ static int get_other_site(struct booth_site **node)
 	return !*node ? 0 : 1;
 }
 
-
-int find_site_by_name(char *site, struct booth_site **node, int any_type)
+int find_site_by_name(struct booth_config *conf_ptr, const char *site,
+                      struct booth_site **node, int any_type)
 {
 	struct booth_site *n;
 	int i;
 
-	if (!booth_conf)
+	if (conf_ptr == NULL)
 		return 0;
 
 	if (!strcmp(site, OTHER_SITE))
-		return get_other_site(node);
+		return get_other_site(conf_ptr, node);
 
-	for (i = 0; i < booth_conf->site_count; i++) {
-		n = booth_conf->site + i;
+	for (i = 0; i < conf_ptr->site_count; i++) {
+		n = conf_ptr->site + i;
 		if ((n->type == SITE || any_type) &&
 		    strncmp(n->addr_string, site, sizeof(n->addr_string)) == 0) {
 			*node = n;

--- a/src/config.c
+++ b/src/config.c
@@ -256,7 +256,7 @@ static int add_ticket(struct booth_config *conf_ptr, const char *name,
 		return -EINVAL;
 	}
 
-	if (find_ticket_by_name(name, NULL)) {
+	if (find_ticket_by_name(conf_ptr, name, NULL)) {
 		log_error("ticket name \"%s\" used again.", name);
 		return -EINVAL;
 	}

--- a/src/config.c
+++ b/src/config.c
@@ -877,6 +877,10 @@ no_value:
 		goto out;
 	}
 
+	safe_copy((*conf_pptr)->path_to_self, path,
+	          sizeof((*conf_pptr)->path_to_self),
+	          "path to config file itself");
+
 	poll_timeout = min(POLL_TIMEOUT, min_timeout/10);
 	if (!poll_timeout)
 		poll_timeout = POLL_TIMEOUT;

--- a/src/config.c
+++ b/src/config.c
@@ -510,8 +510,6 @@ err_out:
 	return -1;
 }
 
-extern int poll_timeout;
-
 int read_config(struct booth_config **conf_pptr,
                 const booth_transport_table_t *transport,
                 const struct ticket_handler *ticket_handler,
@@ -881,9 +879,9 @@ no_value:
 	          sizeof((*conf_pptr)->path_to_self),
 	          "path to config file itself");
 
-	poll_timeout = min(POLL_TIMEOUT, min_timeout/10);
-	if (!poll_timeout)
-		poll_timeout = POLL_TIMEOUT;
+	(*conf_pptr)->poll_timeout = min(POLL_TIMEOUT, min_timeout/10);
+	if ((*conf_pptr)->poll_timeout == 0)
+		(*conf_pptr)->poll_timeout = POLL_TIMEOUT;
 
 	return 0;
 

--- a/src/config.c
+++ b/src/config.c
@@ -1040,3 +1040,25 @@ const char *type_to_string(int type)
 	}
 	return "??invalid-type??";
 }
+
+int find_ticket_by_name(struct booth_config *conf_ptr,
+                        const char *ticket, struct ticket_config **found)
+{
+	struct ticket_config *tk;
+	int i;
+
+	assert(conf_ptr != NULL);
+
+	if (found)
+		*found = NULL;
+
+	FOREACH_TICKET(conf_ptr, i, tk) {
+		if (!strncmp(tk->name, ticket, sizeof(tk->name))) {
+			if (found)
+				*found = tk;
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/src/config.c
+++ b/src/config.c
@@ -513,8 +513,9 @@ err_out:
 extern int poll_timeout;
 
 int read_config(struct booth_config **conf_pptr,
-                const booth_transport_table_t *transport, const char *path,
-                int type)
+                const booth_transport_table_t *transport,
+                const struct ticket_handler *ticket_handler,
+                const char *path, int type)
 {
 	char line[1024];
 	FILE *fp;
@@ -549,6 +550,7 @@ int read_config(struct booth_config **conf_pptr,
 			+ TICKET_ALLOC * sizeof(struct ticket_config));
 	ticket_size = TICKET_ALLOC;
 	(*conf_pptr)->transport = transport;
+	(*conf_pptr)->ticket_handler = ticket_handler;
 
 	(*conf_pptr)->proto = UDP;
 	(*conf_pptr)->port = BOOTH_DEFAULT_PORT;

--- a/src/config.c
+++ b/src/config.c
@@ -953,8 +953,7 @@ static int get_other_site(struct booth_config *conf_ptr,
 	if (conf_ptr == NULL)
 		return 0;
 
-	for (i = 0; i < conf_ptr->site_count; i++) {
-		n = conf_ptr->site + i;
+	FOREACH_NODE(conf_ptr, i, n) {
 		if (n != local && n->type == SITE) {
 			if (!*node) {
 				*node = n;
@@ -979,8 +978,7 @@ int find_site_by_name(struct booth_config *conf_ptr, const char *site,
 	if (!strcmp(site, OTHER_SITE))
 		return get_other_site(conf_ptr, node);
 
-	for (i = 0; i < conf_ptr->site_count; i++) {
-		n = conf_ptr->site + i;
+	FOREACH_NODE(conf_ptr, i, n) {
 		if ((n->type == SITE || any_type) &&
 		    strncmp(n->addr_string, site, sizeof(n->addr_string)) == 0) {
 			*node = n;
@@ -1005,8 +1003,7 @@ int find_site_by_id(struct booth_config *conf_ptr, uint32_t site_id,
 	if (conf_ptr == NULL)
 		return 0;
 
-	for (i = 0; i < conf_ptr->site_count; i++) {
-		n = conf_ptr->site + i;
+	FOREACH_NODE(conf_ptr, i, n) {
 		if (n->site_id == site_id) {
 			*node = n;
 			return 1;

--- a/src/config.c
+++ b/src/config.c
@@ -512,7 +512,9 @@ err_out:
 
 extern int poll_timeout;
 
-int read_config(struct booth_config **conf_pptr, const char *path, int type)
+int read_config(struct booth_config **conf_pptr,
+                const booth_transport_table_t *transport, const char *path,
+                int type)
 {
 	char line[1024];
 	FILE *fp;
@@ -546,13 +548,12 @@ int read_config(struct booth_config **conf_pptr, const char *path, int type)
 	memset(*conf_pptr, 0, sizeof(struct booth_config)
 			+ TICKET_ALLOC * sizeof(struct ticket_config));
 	ticket_size = TICKET_ALLOC;
-
+	(*conf_pptr)->transport = transport;
 
 	(*conf_pptr)->proto = UDP;
 	(*conf_pptr)->port = BOOTH_DEFAULT_PORT;
 	(*conf_pptr)->maxtimeskew = BOOTH_DEFAULT_MAX_TIME_SKEW;
 	(*conf_pptr)->authkey[0] = '\0';
-
 
 	/* Provide safe defaults. -1 is reserved, though. */
 	(*conf_pptr)->uid = -2;

--- a/src/config.c
+++ b/src/config.c
@@ -537,7 +537,7 @@ int read_config(struct booth_config **conf_pptr,
 	struct ticket_config *current_tk = NULL;
 
 	assert(conf_pptr != NULL);
-	free(*conf_pptr);
+	config_free(*conf_pptr);
 
 	fp = fopen(path, "r");
 	if (!fp) {
@@ -901,9 +901,17 @@ out:
 	log_error("%s in config file line %d",
 			error, lineno);
 
-	free(*conf_pptr);
+	config_free(*conf_pptr);
 	*conf_pptr = NULL;
 	return -1;
+}
+
+void config_free(struct booth_config *conf_ptr)
+{
+	if (conf_ptr != NULL) {
+		free(conf_ptr->ticket);
+	}
+	free(conf_ptr);
 }
 
 int check_config(struct booth_config *conf_ptr, int type)

--- a/src/config.c
+++ b/src/config.c
@@ -991,7 +991,8 @@ int find_site_by_name(struct booth_config *conf_ptr, const char *site,
 	return 0;
 }
 
-int find_site_by_id(uint32_t site_id, struct booth_site **node)
+int find_site_by_id(struct booth_config *conf_ptr, uint32_t site_id,
+                    struct booth_site **node)
 {
 	struct booth_site *n;
 	int i;
@@ -1001,11 +1002,11 @@ int find_site_by_id(uint32_t site_id, struct booth_site **node)
 		return 1;
 	}
 
-	if (!booth_conf)
+	if (conf_ptr == NULL)
 		return 0;
 
-	for (i = 0; i < booth_conf->site_count; i++) {
-		n = booth_conf->site + i;
+	for (i = 0; i < conf_ptr->site_count; i++) {
+		n = conf_ptr->site + i;
 		if (n->site_id == site_id) {
 			*node = n;
 			return 1;
@@ -1014,7 +1015,6 @@ int find_site_by_id(uint32_t site_id, struct booth_site **node)
 
 	return 0;
 }
-
 
 const char *type_to_string(int type)
 {

--- a/src/config.h
+++ b/src/config.h
@@ -327,8 +327,17 @@ extern struct booth_config *booth_conf;
 
 #define is_auth_req() (booth_conf->authkey[0] != '\0')
 
-
-int read_config(const char *path, int type);
+/**
+ * @internal
+ * Parse booth configuration file and store as structured data
+ *
+ * @param[inout] conf_pptr config object to free-alloc cycle & fill accordingly
+ * @param[in] path where the configuration file is expected
+ * @param[in] type role currently being acted as
+ *
+ * @return 0 or negative value (-1 or -errno) on error
+ */
+int read_config(struct booth_config **conf_pptr, const char *path, int type);
 
 int check_config(int type);
 

--- a/src/config.h
+++ b/src/config.h
@@ -325,6 +325,7 @@ struct booth_config {
     int ticket_allocated;
     struct ticket_config *ticket;
 
+    int poll_timeout;
     char path_to_self[BOOTH_PATH_LEN];
 
     const booth_transport_table_t *transport;

--- a/src/config.h
+++ b/src/config.h
@@ -346,11 +346,21 @@ struct booth_config {
  * @param[in] type role currently being acted as
  *
  * @return 0 or negative value (-1 or -errno) on error
+ *
+ * @note To eventually dispose the associated memory, use #config_free.
  */
 int read_config(struct booth_config **conf_pptr,
                 const booth_transport_table_t *transport,
                 const struct ticket_handler *ticket_handler,
                 const char *path, int type);
+
+/**
+ * @internal
+ * Memory disposal for the config object
+ *
+ * @param[inout] conf_ptr config object to free
+ */
+void config_free(struct booth_config *conf_ptr);
 
 /**
  * @internal

--- a/src/config.h
+++ b/src/config.h
@@ -22,11 +22,12 @@
 
 #include <stdint.h>
 #include <sys/stat.h>
+
+struct booth_config;
+
 #include "booth.h"
 #include "timer.h"
 #include "raft.h"
-
-struct booth_config;
 #include "transport.h"
 
 

--- a/src/config.h
+++ b/src/config.h
@@ -25,6 +25,8 @@
 #include "booth.h"
 #include "timer.h"
 #include "raft.h"
+
+struct booth_config;
 #include "transport.h"
 
 
@@ -367,7 +369,18 @@ int check_config(struct booth_config *conf_ptr, int type);
 int find_site_by_name(struct booth_config *conf_ptr, const char *site,
                       struct booth_site **node, int any_type);
 
-int find_site_by_id(uint32_t site_id, struct booth_site **node);
+/**
+ * @internal
+ * Find site in booth configuration by a hash (id)
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] site_id hash (id) to match against previously resolved ones
+ * @param[out] node relevant tracked data when found
+ *
+ * @return 0 if nothing found, or 1 when found (node assigned accordingly)
+ */
+int find_site_by_id(struct booth_config *conf_ptr, uint32_t site_id,
+                    struct booth_site **node);
 
 const char *type_to_string(int type);
 

--- a/src/config.h
+++ b/src/config.h
@@ -353,7 +353,20 @@ int read_config(struct booth_config **conf_pptr, const char *path, int type);
  */
 int check_config(struct booth_config *conf_ptr, int type);
 
-int find_site_by_name(char *site, struct booth_site **node, int any_type);
+/**
+ * @internal
+ * Find site in booth configuration by resolved host name
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] site name to match against previously resolved host names
+ * @param[out] node relevant tracked data when found
+ * @param[in] any_type whether or not to consider also non-site members
+ *
+ * @return 0 if nothing found, or 1 when found (node assigned accordingly)
+ */
+int find_site_by_name(struct booth_config *conf_ptr, const char *site,
+                      struct booth_site **node, int any_type);
+
 int find_site_by_id(uint32_t site_id, struct booth_site **node);
 
 const char *type_to_string(int type);

--- a/src/config.h
+++ b/src/config.h
@@ -326,6 +326,7 @@ struct booth_config {
     struct ticket_config *ticket;
 
     const booth_transport_table_t *transport;
+    const struct ticket_handler *ticket_handler;
 };
 
 #define is_auth_req(b_) ((b_)->authkey[0] != '\0')
@@ -342,8 +343,9 @@ struct booth_config {
  * @return 0 or negative value (-1 or -errno) on error
  */
 int read_config(struct booth_config **conf_pptr,
-                const booth_transport_table_t *transport, const char *path,
-                int type);
+                const booth_transport_table_t *transport,
+                const struct ticket_handler *ticket_handler,
+                const char *path, int type);
 
 /**
  * @internal

--- a/src/config.h
+++ b/src/config.h
@@ -328,7 +328,7 @@ struct booth_config {
 
 extern struct booth_config *booth_conf;
 
-#define is_auth_req() (booth_conf->authkey[0] != '\0')
+#define is_auth_req(b_) ((b_)->authkey[0] != '\0')
 
 /**
  * @internal

--- a/src/config.h
+++ b/src/config.h
@@ -395,4 +395,17 @@ int find_site_by_id(struct booth_config *conf_ptr, uint32_t site_id,
 
 const char *type_to_string(int type);
 
+/**
+ * @internal
+ * Pick a ticket structure based on given name
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] ticket name of the ticket to search for
+ * @param[out] found place the reference here when found
+ *
+ * @return see @list_ticket and @send_header_plus
+ */
+int find_ticket_by_name(struct booth_config *conf_ptr,
+                        const char *ticket, struct ticket_config **found);
+
 #endif /* _CONFIG_H */

--- a/src/config.h
+++ b/src/config.h
@@ -324,9 +324,9 @@ struct booth_config {
     int ticket_count;
     int ticket_allocated;
     struct ticket_config *ticket;
-};
 
-extern struct booth_config *booth_conf;
+    const booth_transport_table_t *transport;
+};
 
 #define is_auth_req(b_) ((b_)->authkey[0] != '\0')
 
@@ -335,12 +335,15 @@ extern struct booth_config *booth_conf;
  * Parse booth configuration file and store as structured data
  *
  * @param[inout] conf_pptr config object to free-alloc cycle & fill accordingly
+ * @param[in] transport transport handlers table
  * @param[in] path where the configuration file is expected
  * @param[in] type role currently being acted as
  *
  * @return 0 or negative value (-1 or -errno) on error
  */
-int read_config(struct booth_config **conf_pptr, const char *path, int type);
+int read_config(struct booth_config **conf_pptr,
+                const booth_transport_table_t *transport, const char *path,
+                int type);
 
 /**
  * @internal

--- a/src/config.h
+++ b/src/config.h
@@ -325,6 +325,8 @@ struct booth_config {
     int ticket_allocated;
     struct ticket_config *ticket;
 
+    char path_to_self[BOOTH_PATH_LEN];
+
     const booth_transport_table_t *transport;
     const struct ticket_handler *ticket_handler;
 };

--- a/src/config.h
+++ b/src/config.h
@@ -328,6 +328,8 @@ struct booth_config {
     int poll_timeout;
     char path_to_self[BOOTH_PATH_LEN];
 
+    struct booth_site *local;
+
     const booth_transport_table_t *transport;
     const struct ticket_handler *ticket_handler;
 };

--- a/src/config.h
+++ b/src/config.h
@@ -339,7 +339,19 @@ extern struct booth_config *booth_conf;
  */
 int read_config(struct booth_config **conf_pptr, const char *path, int type);
 
-int check_config(int type);
+/**
+ * @internal
+ * Check booth configuration
+ *
+ * Currently it means checking that login user/group indeed exists,
+ * while converting it to respective numeric values for further use.
+ *
+ * @param[inout] conf_ptr config object to check
+ * @param[in] type role currently being acted as
+ *
+ * @return 0 or negative value (-1 or -errno) on error
+ */
+int check_config(struct booth_config *conf_ptr, int type);
 
 int find_site_by_name(char *site, struct booth_site **node, int any_type);
 int find_site_by_id(uint32_t site_id, struct booth_site **node);

--- a/src/handler.c
+++ b/src/handler.c
@@ -35,15 +35,18 @@
 #include "booth.h"
 #include "handler.h"
 
-static int set_booth_env(struct ticket_config *tk)
+static int set_booth_env(struct booth_config *conf_ptr,
+                         struct ticket_config *tk)
 {
 	int rv;
 	char expires[16];
 
+	assert(conf_ptr != NULL);
+
 	sprintf(expires, "%" PRId64, (int64_t)wall_ts(&tk->term_expires));
 	rv = setenv("BOOTH_TICKET", tk->name, 1) ||
 		setenv("BOOTH_LOCAL", local->addr_string, 1) ||
-		setenv("BOOTH_CONF_NAME", booth_conf->name, 1) ||
+		setenv("BOOTH_CONF_NAME", conf_ptr->name, 1) ||
 		setenv("BOOTH_CONF_PATH", cl.configfile, 1) ||
 		setenv("BOOTH_TICKET_EXPIRES", expires, 1);
 
@@ -65,9 +68,10 @@ closefiles(void)
 }
 
 static void
-run_ext_prog(struct ticket_config *tk, char *prog)
+run_ext_prog(struct booth_config *conf_ptr, struct ticket_config *tk,
+             char *prog)
 {
-	if (set_booth_env(tk)) {
+	if (set_booth_env(conf_ptr, tk)) {
 		_exit(1);
 	}
 	closefiles(); /* don't leak open files */
@@ -125,7 +129,7 @@ int tk_test_exit_status(struct ticket_config *tk)
 	return rv;
 }
 
-void wait_child(int sig)
+void wait_child(struct booth_config *conf_ptr)
 {
 	int i, status;
 	struct ticket_config *tk;
@@ -133,7 +137,7 @@ void wait_child(int sig)
 	/* use waitpid(2) and not wait(2) in order not to interfere
 	 * with popen(2)/pclose(2) and system(2) used in pacemaker.c
 	 */
-	FOREACH_TICKET(booth_conf, i, tk) {
+	FOREACH_TICKET(conf_ptr, i, tk) {
 		if (tk_test.path && tk_test.pid > 0 &&
 				(tk_test.progstate == EXTPROG_RUNNING ||
 				tk_test.progstate == EXTPROG_IGNORE) &&
@@ -187,7 +191,7 @@ void ignore_ext_test(struct ticket_config *tk)
 }
 
 static void
-process_ext_dir(struct ticket_config *tk)
+process_ext_dir(struct booth_config *conf_ptr, struct ticket_config *tk)
 {
 	char prog[FILENAME_MAX+1];
 	int rv, n_progs, i, status;
@@ -220,7 +224,7 @@ process_ext_dir(struct ticket_config *tk)
 			log_error("fork: %s", strerror(errno));
 			_exit(1);
 		case 0: /* child */
-			run_ext_prog(tk, prog);
+			run_ext_prog(conf_ptr, tk, prog);
 			break;  /* run_ext_prog effectively noreturn */
 		default: /* parent */
 			while (waitpid(curr_pid, &status, 0) != curr_pid)
@@ -241,7 +245,7 @@ process_ext_dir(struct ticket_config *tk)
  * RUNCMD_ERR: executing program failed (or some other failure)
  * RUNCMD_MORE: program forked, results later
  */
-int run_handler(struct ticket_config *tk)
+int run_handler(struct booth_config *conf_ptr, struct ticket_config *tk)
 {
 	int rv = 0;
 	pid_t pid;
@@ -262,9 +266,9 @@ int run_handler(struct ticket_config *tk)
 		return RUNCMD_ERR;
 	case 0: /* child */
 		if (tk_test.is_dir) {
-			process_ext_dir(tk);
+			process_ext_dir(conf_ptr, tk);
 		} else {
-			run_ext_prog(tk, tk_test.path);
+			run_ext_prog(conf_ptr, tk, tk_test.path);
 		}
 	default: /* parent */
 		tk_test.pid = pid;

--- a/src/handler.c
+++ b/src/handler.c
@@ -47,7 +47,7 @@ static int set_booth_env(struct booth_config *conf_ptr,
 	rv = setenv("BOOTH_TICKET", tk->name, 1) ||
 		setenv("BOOTH_LOCAL", local->addr_string, 1) ||
 		setenv("BOOTH_CONF_NAME", conf_ptr->name, 1) ||
-		setenv("BOOTH_CONF_PATH", cl.configfile, 1) ||
+		setenv("BOOTH_CONF_PATH", conf_ptr->path_to_self, 1) ||
 		setenv("BOOTH_TICKET_EXPIRES", expires, 1);
 
 	if (rv) {

--- a/src/handler.c
+++ b/src/handler.c
@@ -133,7 +133,7 @@ void wait_child(int sig)
 	/* use waitpid(2) and not wait(2) in order not to interfere
 	 * with popen(2)/pclose(2) and system(2) used in pacemaker.c
 	 */
-	FOREACH_TICKET(i, tk) {
+	FOREACH_TICKET(booth_conf, i, tk) {
 		if (tk_test.path && tk_test.pid > 0 &&
 				(tk_test.progstate == EXTPROG_RUNNING ||
 				tk_test.progstate == EXTPROG_IGNORE) &&

--- a/src/handler.c
+++ b/src/handler.c
@@ -130,7 +130,7 @@ void wait_child(int sig)
 	int i, status;
 	struct ticket_config *tk;
 
-	/* use waitpid(2) and not wait(2) in order not to interfear
+	/* use waitpid(2) and not wait(2) in order not to interfere
 	 * with popen(2)/pclose(2) and system(2) used in pacemaker.c
 	 */
 	foreach_ticket(i, tk) {

--- a/src/handler.c
+++ b/src/handler.c
@@ -133,7 +133,7 @@ void wait_child(int sig)
 	/* use waitpid(2) and not wait(2) in order not to interfere
 	 * with popen(2)/pclose(2) and system(2) used in pacemaker.c
 	 */
-	foreach_ticket(i, tk) {
+	FOREACH_TICKET(i, tk) {
 		if (tk_test.path && tk_test.pid > 0 &&
 				(tk_test.progstate == EXTPROG_RUNNING ||
 				tk_test.progstate == EXTPROG_IGNORE) &&

--- a/src/handler.c
+++ b/src/handler.c
@@ -42,10 +42,11 @@ static int set_booth_env(struct booth_config *conf_ptr,
 	char expires[16];
 
 	assert(conf_ptr != NULL);
+	assert(conf_ptr->local != NULL);
 
 	sprintf(expires, "%" PRId64, (int64_t)wall_ts(&tk->term_expires));
 	rv = setenv("BOOTH_TICKET", tk->name, 1) ||
-		setenv("BOOTH_LOCAL", local->addr_string, 1) ||
+		setenv("BOOTH_LOCAL", conf_ptr->local->addr_string, 1) ||
 		setenv("BOOTH_CONF_NAME", conf_ptr->name, 1) ||
 		setenv("BOOTH_CONF_PATH", conf_ptr->path_to_self, 1) ||
 		setenv("BOOTH_TICKET_EXPIRES", expires, 1);

--- a/src/handler.h
+++ b/src/handler.h
@@ -24,12 +24,30 @@ enum {
 	RUNCMD_MORE = -2,
 };
 
-int run_handler(struct ticket_config *tk);
+/**
+ * @internal
+ * First stage of incoming datagram handling (authentication)
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] tk ticket at hand
+ *
+ * @return 0, #RUNCMD_ERR, #RUNCMD_MORE
+ */
+int run_handler(struct booth_config *conf_ptr, struct ticket_config *tk);
+
 int tk_test_exit_status(struct ticket_config *tk);
 void ignore_ext_test(struct ticket_config *tk);
 int is_ext_prog_running(struct ticket_config *tk);
 void ext_prog_timeout(struct ticket_config *tk);
-void wait_child(int sig);
+
+/**
+ * @internal
+ * SIGCHLD handling so as to mark the handler-at-a-ticket finalization
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] tk ticket at hand
+ */
+void wait_child(struct booth_config *conf_ptr);
 
 #define set_progstate(tk, newst) do { \
 	if (!(newst)) tk_log_debug("progstate reset"); \

--- a/src/inline-fn.h
+++ b/src/inline-fn.h
@@ -150,10 +150,11 @@ static inline void init_ticket_msg(struct booth_config *conf_ptr,
 	}
 }
 
-/* XXX uses globals: booth_transport, booth_conf */
-static inline struct booth_transport const *transport(void)
+static inline struct booth_transport const *transport(struct booth_config *conf_ptr)
 {
-	return booth_transport + booth_conf->proto;
+	assert(conf_ptr != NULL && conf_ptr->transport != NULL);
+
+	return *conf_ptr->transport + conf_ptr->proto;
 }
 
 static inline const char *site_string(const struct booth_site *site)

--- a/src/inline-fn.h
+++ b/src/inline-fn.h
@@ -153,11 +153,31 @@ static inline struct booth_transport const *transport(void)
 }
 
 
-static inline const char *site_string(struct booth_site *site)
+static inline const char *site_string(const struct booth_site *site)
 {
 	return site ? site->addr_string : "NONE";
 }
 
+/**
+ * @internal
+ * Parse booth configuration file and store as structured data
+ *
+ * @param[in] site subject of TCP/UDP port extraction
+ *
+ * @return 0 for "undefined", actual port number otherwise
+ */
+static inline uint16_t site_port(const struct booth_site *site)
+{
+	assert(site != NULL);
+
+	return site
+		? site->family == AF_INET
+			? ntohs(site->sa4.sin_port)
+			: site->family == AF_INET6
+				? ntohs(site->sa6.sin6_port)
+				: 0
+		: 0;
+}
 
 static inline const char *ticket_leader_string(struct ticket_config *tk)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -383,7 +383,8 @@ static int setup_config(struct booth_config **conf_pptr, int type)
 		}
 		local->local = 1;
 	} else
-		find_myself(NULL, type == CLIENT || type == GEOSTORE);
+		find_myself(booth_conf, NULL,
+		            type == CLIENT || type == GEOSTORE);
 
 
 	rv = check_config(booth_conf, type);

--- a/src/main.c
+++ b/src/main.c
@@ -493,7 +493,7 @@ static int loop(int fd)
 	if (rv < 0)
 		goto fail;
 
-	rv = setup_ticket();
+	rv = setup_ticket(booth_conf);
 	if (rv < 0)
 		goto fail;
 
@@ -799,7 +799,7 @@ read_more:
 	if (rv == 1) {
 		tpt->close(site);
 		leader_id = ntohl(reply.ticket.leader);
-		if (!find_site_by_id(leader_id, &site)) {
+		if (!find_site_by_id(booth_conf, leader_id, &site)) {
 			log_error("Message with unknown redirect site %x received", leader_id);
 			rv = -1;
 			goto out_close;

--- a/src/main.c
+++ b/src/main.c
@@ -65,6 +65,7 @@
 #include "inline-fn.h"
 #include "pacemaker.h"
 #include "ticket.h"
+#include "utils.h"
 #include "request.h"
 #include "attr.h"
 #include "handler.h"
@@ -982,20 +983,6 @@ static void print_usage(void)
 
 #define OPTION_STRING		"c:Dl:t:s:FhSwC"
 #define ATTR_OPTION_STRING		"c:Dt:s:h"
-
-void safe_copy(char *dest, const char *value, size_t buflen,
-               const char *description)
-{
-	int content_len = buflen - 1;
-
-	if (strlen(value) >= content_len) {
-		fprintf(stderr, "'%s' exceeds maximum %s length of %d\n",
-			value, description, content_len);
-		exit(EXIT_FAILURE);
-	}
-	strncpy(dest, value, content_len);
-	dest[content_len] = 0;
-}
 
 static int host_convert(char *hostname, char *ip_str, size_t ip_size)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -75,6 +75,7 @@
 #define CLIENT_NALLOC		32
 
 extern const booth_transport_table_t booth__transport;
+extern struct ticket_handler booth__pcmk_ticket_handler;
 
 static int daemonize = 1;
 int enable_stderr = 0;
@@ -364,7 +365,8 @@ static int setup_config(struct booth_config **conf_pptr, int type)
 
 	assert(conf_pptr != NULL);
 
-	rv = read_config(conf_pptr, &booth__transport, cl.configfile, type);
+	rv = read_config(conf_pptr, &booth__transport,
+	                 &booth__pcmk_ticket_handler, cl.configfile, type);
 	if (rv < 0)
 		goto out;
 

--- a/src/main.c
+++ b/src/main.c
@@ -108,8 +108,6 @@ typedef enum
 	BOOTHD_STARTING
 } BOOTH_DAEMON_STATE;
 
-int poll_timeout;
-
 static void client_alloc(void)
 {
 	int i;
@@ -523,7 +521,7 @@ static int loop(struct command_line *cl, struct booth_config *conf_ptr, int fd)
 			local->site_id, local->site_id);
 
 	while (1) {
-		rv = poll(pollfds, client_maxi + 1, poll_timeout);
+		rv = poll(pollfds, client_maxi + 1, conf_ptr->poll_timeout);
 		if (rv == -1 && errno == EINTR)
 			continue;
 		if (rv < 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -386,7 +386,7 @@ static int setup_config(struct booth_config **conf_pptr, int type)
 		find_myself(NULL, type == CLIENT || type == GEOSTORE);
 
 
-	rv = check_config(type);
+	rv = check_config(booth_conf, type);
 	if (rv < 0)
 		goto out;
 

--- a/src/main.c
+++ b/src/main.c
@@ -680,7 +680,7 @@ static int query_get_string_answer(cmd_request_t cmd)
 	if (rv < 0)
 		goto out_close;
 
-	rv = tpt->recv_auth(site, &reply, sizeof(reply));
+	rv = tpt->recv_auth(booth_conf, site, &reply, sizeof(reply));
 	if (rv < 0)
 		goto out_close;
 
@@ -784,7 +784,7 @@ redirect:
 		goto out_close;
 
 read_more:
-	rv = tpt->recv_auth(site, &reply, sizeof(reply));
+	rv = tpt->recv_auth(booth_conf, site, &reply, sizeof(reply));
 	if (rv < 0) {
 		/* print any errors depending on the code sent by the
 		 * server */

--- a/src/main.c
+++ b/src/main.c
@@ -1640,6 +1640,8 @@ int main(int argc, char *argv[], char *envp[])
 	}
 
 out:
+	config_free(booth_conf);
+
 #ifdef LOGGING_LIBQB
 	qb_log_fini();
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -349,11 +349,13 @@ int update_authkey()
 	return 0;
 }
 
-static int setup_config(int type)
+static int setup_config(struct booth_config **conf_pptr, int type)
 {
 	int rv;
 
-	rv = read_config(cl.configfile, type);
+	assert(conf_pptr != NULL);
+
+	rv = read_config(conf_pptr, cl.configfile, type);
 	if (rv < 0)
 		goto out;
 
@@ -392,8 +394,8 @@ static int setup_config(int type)
 	/* Per default the PID file name is derived from the
 	 * configuration name. */
 	if (!cl.lockfile[0]) {
-		snprintf(cl.lockfile, sizeof(cl.lockfile)-1,
-				"%s/%s.pid", BOOTH_RUN_DIR, booth_conf->name);
+		snprintf(cl.lockfile, sizeof(cl.lockfile) - 1,
+		         "%s/%s.pid", BOOTH_RUN_DIR, (*conf_pptr)->name);
 	}
 
 out:
@@ -1291,17 +1293,18 @@ static int set_procfs_val(const char *path, const char *val)
 	return rc;
 }
 
-static int do_status(int type)
+static int do_status(struct booth_config **conf_pptr, int type)
 {
 	pid_t pid;
 	int rv, status_lock_fd, ret;
 	const char *reason = NULL;
 	char lockfile_data[1024], *cp;
 
+	assert(conf_pptr != NULL);
 
 	ret = PCMK_OCF_NOT_RUNNING;
 
-	rv = setup_config(type);
+	rv = setup_config(conf_pptr, type);
 	if (rv) {
 		reason = "Error reading configuration.";
 		ret = PCMK_OCF_UNKNOWN_ERROR;
@@ -1363,7 +1366,7 @@ static int do_status(int type)
 			cl.lockfile, lockfile_data);
 	if (!daemonize)
 		fprintf(stderr, "Booth at %s port %d seems to be running.\n",
-				local->addr_string, booth_conf->port);
+		        local->addr_string, (*conf_pptr)->port);
 	return 0;
 
 
@@ -1419,12 +1422,14 @@ static void sig_exit_handler(int sig)
 	exit(0);
 }
 
-static int do_server(int type)
+static int do_server(struct booth_config **conf_pptr, int type)
 {
 	int rv = -1;
 	static char log_ent[128] = DAEMON_NAME "-";
 
-	rv = setup_config(type);
+	assert(conf_pptr != NULL);
+
+	rv = setup_config(conf_pptr, type);
 	if (rv < 0)
 		return rv;
 
@@ -1468,11 +1473,8 @@ static int do_server(int type)
 	if (set_procfs_val("/proc/self/oom_score_adj", "-999"))
 		(void)set_procfs_val("/proc/self/oom_adj", "-16");
 	set_proc_title("%s %s %s for [%s]:%d",
-			DAEMON_NAME,
-			cl.configfile,
-			type_to_string(local->type),
-			local->addr_string,
-			booth_conf->port);
+	               DAEMON_NAME, cl.configfile, type_to_string(local->type),
+	               local->addr_string, (*conf_pptr)	->port);
 
 	rv = limit_this_process();
 	if (rv)
@@ -1496,11 +1498,11 @@ static int do_server(int type)
 	return rv;
 }
 
-static int do_client(void)
+static int do_client(struct booth_config **conf_pptr)
 {
 	int rv;
 
-	rv = setup_config(CLIENT);
+	rv = setup_config(conf_pptr, CLIENT);
 	if (rv < 0) {
 		log_error("cannot read config");
 		goto out;
@@ -1522,11 +1524,13 @@ out:
 	return rv;
 }
 
-static int do_attr(void)
+static int do_attr(struct booth_config **conf_pptr)
 {
 	int rv = -1;
 
-	rv = setup_config(GEOSTORE);
+	assert(conf_pptr != NULL);
+
+	rv = setup_config(conf_pptr, GEOSTORE);
 	if (rv < 0) {
 		log_error("cannot read config");
 		goto out;
@@ -1537,9 +1541,10 @@ static int do_attr(void)
 	 * Although, that means that the UDP port has to be specified, too. */
 	if (!cl.attr_msg.attr.tkt_id[0]) {
 		/* If the loaded configuration has only a single ticket defined, use that. */
-		if (booth_conf->ticket_count == 1) {
-			strncpy(cl.attr_msg.attr.tkt_id, booth_conf->ticket[0].name,
-				sizeof(cl.attr_msg.attr.tkt_id));
+		if ((*conf_pptr)->ticket_count == 1) {
+			strncpy(cl.attr_msg.attr.tkt_id,
+			        (*conf_pptr)->ticket[0].name,
+			        sizeof(cl.attr_msg.attr.tkt_id));
 		} else {
 			rv = 1;
 			log_error("No ticket given.");
@@ -1606,21 +1611,21 @@ int main(int argc, char *argv[], char *envp[])
 
 	switch (cl.type) {
 	case STATUS:
-		rv = do_status(cl.type);
+		rv = do_status(&booth_conf, cl.type);
 		break;
 
 	case ARBITRATOR:
 	case DAEMON:
 	case SITE:
-		rv = do_server(cl.type);
+		rv = do_server(&booth_conf, cl.type);
 		break;
 
 	case CLIENT:
-		rv = do_client();
+		rv = do_client(&booth_conf);
 		break;
 
 	case GEOSTORE:
-		rv = do_attr();
+		rv = do_attr(&booth_conf);
 		break;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -431,22 +431,19 @@ static int write_daemon_state(int fd, int state)
 
 	size = sizeof(buffer) - 1;
 	rv = snprintf(buffer, size,
-			"booth_pid=%d "
-			"booth_state=%s "
-			"booth_type=%s "
-			"booth_cfg_name='%s' "
-			"booth_id=%d "
-			"booth_addr_string='%s' "
-			"booth_port=%d\n",
-		getpid(), 
-		( state == BOOTHD_STARTED  ? "started"  : 
-		  state == BOOTHD_STARTING ? "starting" : 
-		  "invalid"), 
-		type_to_string(local->type),
-		booth_conf->name,
-		local->site_id,
-		local->addr_string,
-		booth_conf->port);
+	              "booth_pid=%d "
+	              "booth_state=%s "
+	              "booth_type=%s "
+	              "booth_cfg_name='%s' "
+	              "booth_id=%d "
+	              "booth_addr_string='%s' "
+	              "booth_port=%d\n",
+	              getpid(),
+	              ( state == BOOTHD_STARTED  ? "started"  :
+	                  state == BOOTHD_STARTING ? "starting" : "invalid"),
+	              type_to_string(local->type), booth_conf->name,
+	              get_local_id(), site_string(local),
+	              site_port(local));
 
 	if (rv < 0 || rv == size) {
 		log_error("Buffer filled up in write_daemon_state().");
@@ -1367,7 +1364,7 @@ static int do_status(struct booth_config **conf_pptr, int type)
 			cl.lockfile, lockfile_data);
 	if (!daemonize)
 		fprintf(stderr, "Booth at %s port %d seems to be running.\n",
-		        local->addr_string, (*conf_pptr)->port);
+		        site_string(local), site_port(local));
 	return 0;
 
 
@@ -1475,7 +1472,7 @@ static int do_server(struct booth_config **conf_pptr, int type)
 		(void)set_procfs_val("/proc/self/oom_adj", "-16");
 	set_proc_title("%s %s %s for [%s]:%d",
 	               DAEMON_NAME, cl.configfile, type_to_string(local->type),
-	               local->addr_string, (*conf_pptr)	->port);
+	               site_string(local), site_port(local));
 
 	rv = limit_this_process();
 	if (rv)

--- a/src/main.c
+++ b/src/main.c
@@ -268,7 +268,8 @@ void list_peers(struct booth_config *conf_ptr, int fd)
 	if (format_peers(&data, &olen) < 0)
 		goto out;
 
-	init_header(&hdr.header, CL_LIST, 0, 0, RLT_SUCCESS, 0, sizeof(hdr) + olen);
+	init_header(conf_ptr, &hdr.header, CL_LIST, 0, 0, RLT_SUCCESS,
+	            0, sizeof(hdr) + olen);
 	(void) send_header_plus(conf_ptr, fd, &hdr, data, olen);
 
 out:
@@ -358,7 +359,7 @@ static int setup_config(struct booth_config **conf_pptr, int type)
 	if (rv < 0)
 		goto out;
 
-	if (is_auth_req()) {
+	if (is_auth_req(booth_conf)) {
 		rv = read_authkey();
 		if (rv < 0)
 			goto out;
@@ -661,7 +662,7 @@ static int query_get_string_answer(cmd_request_t cmd)
 	header = (struct boothc_header *)request;
 	data = NULL;
 
-	init_header(header, cmd, 0, cl.options, 0, 0, msg_size);
+	init_header(booth_conf, header, cmd, 0, cl.options, 0, 0, msg_size);
 
 	if (!*cl.site)
 		site = local;
@@ -773,7 +774,7 @@ static int do_command(cmd_request_t cmd)
 	}
 
 redirect:
-	init_header(&cl.msg.header, cmd, 0, cl.options, 0, 0, sizeof(cl.msg));
+	init_header(booth_conf, &cl.msg.header, cmd, 0, cl.options, 0, 0, sizeof(cl.msg));
 
 	rv = tpt->open(site);
 	if (rv < 0)

--- a/src/main.c
+++ b/src/main.c
@@ -259,8 +259,7 @@ static int format_peers(char **pdata, unsigned int *len)
 	return 0;
 }
 
-
-void list_peers(int fd)
+void list_peers(struct booth_config *conf_ptr, int fd)
 {
 	char *data;
 	unsigned int olen;
@@ -270,7 +269,7 @@ void list_peers(int fd)
 		goto out;
 
 	init_header(&hdr.header, CL_LIST, 0, 0, RLT_SUCCESS, 0, sizeof(hdr) + olen);
-	(void)send_header_plus(fd, &hdr, data, olen);
+	(void) send_header_plus(conf_ptr, fd, &hdr, data, olen);
 
 out:
 	if (data)
@@ -677,7 +676,7 @@ static int query_get_string_answer(cmd_request_t cmd)
 	if (rv < 0)
 		goto out_close;
 
-	rv = tpt->send(site, request, msg_size);
+	rv = tpt->send(booth_conf, site, request, msg_size);
 	if (rv < 0)
 		goto out_close;
 
@@ -780,7 +779,7 @@ redirect:
 	if (rv < 0)
 		goto out_close;
 
-	rv = tpt->send(site, &cl.msg, sendmsglen(&cl.msg));
+	rv = tpt->send(booth_conf, site, &cl.msg, sendmsglen(&cl.msg));
 	if (rv < 0)
 		goto out_close;
 

--- a/src/main.c
+++ b/src/main.c
@@ -223,7 +223,7 @@ static int format_peers(char **pdata, unsigned int *len)
 		return -ENOMEM;
 
 	cp = data;
-	foreach_node(i, s) {
+	FOREACH_NODE(i, s) {
 		if (s == local)
 			continue;
 		strftime(time_str, sizeof(time_str), "%F %T",

--- a/src/main.c
+++ b/src/main.c
@@ -155,7 +155,7 @@ static void client_dead(int ci)
 }
 
 int client_add(int fd, const struct booth_transport *tpt,
-		void (*workfn)(int ci),
+		void (*workfn)(struct booth_config *conf_ptr, int ci),
 		void (*deadfn)(int ci))
 {
 	int i;
@@ -223,7 +223,7 @@ static int format_peers(char **pdata, unsigned int *len)
 		return -ENOMEM;
 
 	cp = data;
-	FOREACH_NODE(i, s) {
+	FOREACH_NODE(booth_conf, i, s) {
 		if (s == local)
 			continue;
 		strftime(time_str, sizeof(time_str), "%F %T",
@@ -483,7 +483,7 @@ static int write_daemon_state(int fd, int state)
 
 static int loop(int fd)
 {
-	void (*workfn) (int ci);
+	void (*workfn) (struct booth_config *conf_ptr, int ci);
 	void (*deadfn) (int ci);
 	int rv, i;
 
@@ -522,7 +522,7 @@ static int loop(int fd)
 			if (pollfds[i].revents & POLLIN) {
 				workfn = clients[i].workfn;
 				if (workfn)
-					workfn(i);
+					workfn(booth_conf, i);
 			}
 			if (pollfds[i].revents &
 					(POLLERR | POLLHUP | POLLNVAL)) {
@@ -532,7 +532,7 @@ static int loop(int fd)
 			}
 		}
 
-		process_tickets();
+		process_tickets(booth_conf);
 	}
 
 	return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -1420,6 +1420,11 @@ static void sig_exit_handler(int sig)
 	exit(0);
 }
 
+static void wait_child_adaptor(int sig)
+{
+	wait_child(booth_conf);
+}
+
 static int do_server(struct booth_config **conf_pptr, int type)
 {
 	int rv = -1;
@@ -1490,7 +1495,7 @@ static int do_server(struct booth_config **conf_pptr, int type)
 	}
 #endif
 
-	signal(SIGCHLD, (__sighandler_t)wait_child);
+	signal(SIGCHLD, (__sighandler_t) wait_child_adaptor);
 	rv = loop(lock_fd);
 
 	return rv;

--- a/src/main.c
+++ b/src/main.c
@@ -376,7 +376,7 @@ static int setup_config(struct booth_config **conf_pptr, int type)
 
 	/* Set "local" pointer, ignoring errors. */
 	if (cl.type == DAEMON && cl.site[0]) {
-		if (!find_site_by_name(cl.site, &local, 1)) {
+		if (!find_site_by_name(booth_conf, cl.site, &local, 1)) {
 			log_error("Cannot find \"%s\" in the configuration.",
 					cl.site);
 			return -EINVAL;
@@ -668,7 +668,7 @@ static int query_get_string_answer(cmd_request_t cmd)
 
 	if (!*cl.site)
 		site = local;
-	else if (!find_site_by_name(cl.site, &site, 1)) {
+	else if (!find_site_by_name(booth_conf, cl.site, &site, 1)) {
 		log_error("cannot find site \"%s\"", cl.site);
 		rv = ENOENT;
 		goto out;
@@ -744,7 +744,7 @@ static int do_command(cmd_request_t cmd)
 	if (!*cl.site)
 		site = local;
 	else {
-		if (!find_site_by_name(cl.site, &site, 1)) {
+		if (!find_site_by_name(booth_conf, cl.site, &site, 1)) {
 			log_error("Site \"%s\" not configured.", cl.site);
 			goto out_close;
 		}
@@ -1560,7 +1560,7 @@ static int do_attr(struct booth_config **conf_pptr)
 
 	case ATTR_SET:
 	case ATTR_DEL:
-		rv = do_attr_command(cl.op);
+		rv = do_attr_command(booth_conf, cl.op);
 		break;
 	}
 

--- a/src/manual.c
+++ b/src/manual.c
@@ -34,7 +34,10 @@ int manual_selection(struct booth_config *conf_ptr,
                      struct ticket_config *tk, struct booth_site *preference,
                      int update_term, cmd_reason_t reason)
 {
-	if (local->type != SITE)
+	assert(conf_ptr != NULL);
+	assert(conf_ptr->local != NULL);
+
+	if (conf_ptr->local->type != SITE)
 		return 0;
 
 	tk_log_debug("starting manual selection (caused by %s %s)",
@@ -42,7 +45,7 @@ int manual_selection(struct booth_config *conf_ptr,
 				reason == OR_AGAIN ? state_to_string(tk->election_reason) : "" );
 
 	// Manual selection is done without any delay, the leader is assigned
-	set_leader(tk, local);
+	set_leader(tk, conf_ptr->local);
 	set_state(tk, ST_LEADER);
 
 	// Manual tickets never expire, we don't specify expiration time

--- a/src/manual.c
+++ b/src/manual.c
@@ -18,9 +18,9 @@
 
 #include "manual.h"
 
+#include "config.h"
 #include "transport.h"
 #include "ticket.h"
-#include "config.h"
 #include "log.h"
 #include "request.h"
 

--- a/src/manual.c
+++ b/src/manual.c
@@ -83,7 +83,7 @@ int process_REVOKE_for_manual_ticket(struct booth_config *conf_ptr,
 	// (and which had sent this message).
 
 	// We send the ACK, to satisfy the requestor.
-	rv = send_msg(OP_ACK, tk, sender, msg);		
+	rv = send_msg(conf_ptr, OP_ACK, tk, sender, msg);		
 
 	// Mark this ticket as not granted to the sender anymore.
 	mark_ticket_as_revoked(tk, sender);

--- a/src/manual.c
+++ b/src/manual.c
@@ -30,8 +30,9 @@
  * and the current node doesn't have to wait for any responses
  * from other sites.
  */
-int manual_selection(struct ticket_config *tk,
-	struct booth_site *preference, int update_term, cmd_reason_t reason)
+int manual_selection(struct booth_config *conf_ptr,
+                     struct ticket_config *tk, struct booth_site *preference,
+                     int update_term, cmd_reason_t reason)
 {
 	if (local->type != SITE)
 		return 0;
@@ -56,7 +57,7 @@ int manual_selection(struct ticket_config *tk,
 	save_committed_tkt(tk);
 
 	// Inform others about the new leader
-	ticket_broadcast(tk, OP_HEARTBEAT, OP_ACK, RLT_SUCCESS, 0);
+	ticket_broadcast(conf_ptr, tk, OP_HEARTBEAT, OP_ACK, RLT_SUCCESS, 0);
 	tk->ticket_updated = 0;
 
 	return 0;
@@ -66,10 +67,10 @@ int manual_selection(struct ticket_config *tk,
  * revoked from another site, which this site doesn't
  * consider as a leader.
  */
-int process_REVOKE_for_manual_ticket (
-	struct ticket_config *tk,
-	struct booth_site *sender,
-	struct boothc_ticket_msg *msg)
+int process_REVOKE_for_manual_ticket(struct booth_config *conf_ptr,
+                                     struct ticket_config *tk,
+                                     struct booth_site *sender,
+                                     struct boothc_ticket_msg *msg)
 {
 	int rv;
 
@@ -94,7 +95,8 @@ int process_REVOKE_for_manual_ticket (
 
 		// Because another leader is presumably stepping down,
 		// let's notify other sites that now we are the only leader.
-		ticket_broadcast(tk, OP_HEARTBEAT, OP_ACK, RLT_SUCCESS, 0);
+		ticket_broadcast(conf_ptr, tk, OP_HEARTBEAT, OP_ACK,
+		                 RLT_SUCCESS, 0);
 	} else {
 		tk_log_warn("%s wants to revoke ticket, "
 			"but this site is not following it",

--- a/src/manual.h
+++ b/src/manual.h
@@ -23,13 +23,36 @@
 
 struct ticket_config;
 
-int manual_selection(struct ticket_config *tk,
-		struct booth_site *new_leader, int update_term, cmd_reason_t reason);
+/**
+ * @internal
+ * Assign a local site as a leader for the ticket
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] tk ticket at hand
+ * @param[in] preference unused
+ * @param[in] update_term unused
+ * @param[in] reason explains why new "election" is conducted
+ *
+ * @return see #send_msg
+ */
+int manual_selection(struct booth_config *conf_ptr,
+                     struct ticket_config *tk, struct booth_site *preference,
+                     int update_term, cmd_reason_t reason);
 
-int process_REVOKE_for_manual_ticket (
-		struct ticket_config *tk,
-		struct booth_site *sender,
-		struct boothc_ticket_msg *msg);
-
+/**
+ * @internal
+ * Handle REVOKE message
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] tk ticket at hand
+ * @param[in] sender site structure of the sender
+ * @param[in] msg message to deal with
+ *
+ * @return 0 on success (only possible outcome)
+ */
+int process_REVOKE_for_manual_ticket(struct booth_config *conf_ptr,
+                                     struct ticket_config *tk,
+                                     struct booth_site *sender,
+                                     struct boothc_ticket_msg *msg);
 
 #endif /* _MANUAL_H */

--- a/src/pacemaker.c
+++ b/src/pacemaker.c
@@ -494,6 +494,9 @@ static int pcmk_load_ticket(struct booth_config *conf_ptr,
 	int rv = 0, pipe_rv;
 	FILE *p;
 
+	assert(conf_ptr != NULL);
+	assert(conf_ptr->local != NULL);
+
 	/* This here gets run during startup; testing that here means that
 	 * normal operation won't be interrupted with that test. */
 	test_atomicity();
@@ -523,7 +526,7 @@ static int pcmk_load_ticket(struct booth_config *conf_ptr,
 		if (tk->is_granted) {
 			log_warn("%s: granted here, assume it belonged to us",
 				tk->name);
-			set_leader(tk, local);
+			set_leader(tk, conf_ptr->local);
 		}
 	}
 

--- a/src/pacemaker.c
+++ b/src/pacemaker.c
@@ -538,8 +538,7 @@ static int pcmk_load_ticket(struct booth_config *conf_ptr,
 	return rv | pipe_rv;
 }
 
-
-struct ticket_handler pcmk_handler = {
+struct ticket_handler booth__pcmk_ticket_handler = {
 	.grant_ticket   = pcmk_grant_ticket,
 	.revoke_ticket  = pcmk_revoke_ticket,
 	.load_ticket    = pcmk_load_ticket,

--- a/src/pacemaker.c
+++ b/src/pacemaker.c
@@ -265,8 +265,9 @@ static int pcmk_store_ticket_nonatomic(struct ticket_config *tk)
 	return rv;
 }
 
-typedef int (*attr_f)(struct ticket_config *tk, const char *name,
-		      const char *val);
+typedef int (*attr_f)(struct booth_config *conf_ptr,
+                      struct ticket_config *tk, const char *name,
+                      const char *val);
 
 struct attr_tab
 {
@@ -274,15 +275,17 @@ struct attr_tab
 	attr_f handling_f;
 };
 
-static int save_expires(struct ticket_config *tk, const char *name,
-			const char *val)
+static int save_expires(struct booth_config *unused,
+                        struct ticket_config *tk, const char *name,
+                        const char *val)
 {
 	secs2tv(unwall_ts(atol(val)), &tk->term_expires);
 	return 0;
 }
 
-static int save_term(struct ticket_config *tk, const char *name,
-		     const char *val)
+static int save_term(struct booth_config *unused,
+                     struct ticket_config *tk, const char *name,
+                     const char *val)
 {
 	tk->current_term = atol(val);
 	return 0;
@@ -302,23 +305,26 @@ static int parse_boolean(const char *val)
 	return v;
 }
 
-static int save_granted(struct ticket_config *tk, const char *name,
-			const char *val)
+static int save_granted(struct booth_config *unused,
+                        struct ticket_config *tk, const char *name,
+                        const char *val)
 {
 	tk->is_granted = parse_boolean(val);
 	return 0;
 }
 
-static int save_owner(struct ticket_config *tk, const char *name,
-		      const char *val)
+static int save_owner(struct booth_config *conf_ptr,
+                      struct ticket_config *tk, const char *name,
+                      const char *val)
 {
 	/* No check, node could have been deconfigured. */
 	tk->leader = NULL;
-	return !find_site_by_id(atol(val), &tk->leader);
+	return !find_site_by_id(conf_ptr, atol(val), &tk->leader);
 }
 
-static int ignore_attr(struct ticket_config *tk, const char *name,
-		       const char *val)
+static int ignore_attr(struct booth_config *unused,
+                       struct ticket_config *tk, const char *name,
+                       const char *val)
 {
 	return 0;
 }
@@ -384,7 +390,8 @@ out:
 	return rv;
 }
 
-static int save_attributes(struct ticket_config *tk, xmlDocPtr doc)
+static int save_attributes(struct booth_config *conf_ptr,
+                           struct ticket_config *tk, xmlDocPtr doc)
 {
 	int rv = 0, rc;
 	xmlNodePtr n;
@@ -405,8 +412,9 @@ static int save_attributes(struct ticket_config *tk, xmlDocPtr doc)
 		v = xmlGetProp(n, attr->name);
 		for (atp = attr_handlers; atp->name; atp++) {
 			if (!strcmp(atp->name, (const char *) attr->name)) {
-				rc = atp->handling_f(tk, (const char *) attr->name,
-						     (const char *) v);
+				rc = atp->handling_f(conf_ptr, tk,
+				                     (const char *) attr->name,
+				                     (const char *) v);
 				break;
 			}
 		}
@@ -426,7 +434,8 @@ static int save_attributes(struct ticket_config *tk, xmlDocPtr doc)
 
 #define CHUNK_SIZE 256
 
-static int parse_ticket_state(struct ticket_config *tk, FILE *p)
+static int parse_ticket_state(struct booth_config *conf_ptr,
+                              struct ticket_config *tk, FILE *p)
 {
 	int rv = 0;
 	GString *input = NULL;
@@ -468,7 +477,7 @@ static int parse_ticket_state(struct ticket_config *tk, FILE *p)
 		rv = -EINVAL;
 		goto out;
 	}
-	rv = save_attributes(tk, doc);
+	rv = save_attributes(conf_ptr, tk, doc);
 
 out:
 	if (doc)
@@ -478,7 +487,8 @@ out:
 	return rv;
 }
 
-static int pcmk_load_ticket(struct ticket_config *tk)
+static int pcmk_load_ticket(struct booth_config *conf_ptr,
+                            struct ticket_config *tk)
 {
 	char cmd[COMMAND_MAX];
 	int rv = 0, pipe_rv;
@@ -500,7 +510,7 @@ static int pcmk_load_ticket(struct ticket_config *tk)
 		return pipe_rv || -EINVAL;
 	}
 
-	rv = parse_ticket_state(tk, p);
+	rv = parse_ticket_state(conf_ptr, tk, p);
 
 	if (!tk->leader) {
 		/* Hmm, no site found for the ticket we have in the

--- a/src/pacemaker.h
+++ b/src/pacemaker.h
@@ -26,7 +26,7 @@
 struct ticket_handler {
 	int (*grant_ticket) (struct ticket_config *tk);
 	int (*revoke_ticket) (struct ticket_config *tk);
-	int (*load_ticket) (struct ticket_config *tk);
+	int (*load_ticket) (struct booth_config *conf_ptr, struct ticket_config *tk);
 	int (*set_attr) (struct ticket_config *tk, const char *a, const char *v);
 	int (*get_attr) (struct ticket_config *tk, const char *a, const char **vp);
 	int (*del_attr) (struct ticket_config *tk, const char *a);

--- a/src/pacemaker.h
+++ b/src/pacemaker.h
@@ -32,8 +32,6 @@ struct ticket_handler {
 	int (*del_attr) (struct ticket_config *tk, const char *a);
 };
 
-struct ticket_handler pcmk_handler;
 const char * interpret_rv(int rv);
-
 
 #endif /* _PACEMAKER_H */

--- a/src/raft.c
+++ b/src/raft.c
@@ -23,9 +23,9 @@
 #include <arpa/inet.h>
 #include "booth.h"
 #include "timer.h"
+#include "config.h"
 #include "transport.h"
 #include "inline-fn.h"
-#include "config.h"
 #include "raft.h"
 #include "ticket.h"
 #include "request.h"

--- a/src/raft.c
+++ b/src/raft.c
@@ -40,7 +40,7 @@ inline static void clear_election(struct ticket_config *tk)
 
 	tk_log_debug("clear election");
 	tk->votes_received = 0;
-	foreach_node(i, site)
+	FOREACH_NODE(i, site)
 		tk->votes_for[site->index] = NULL;
 }
 

--- a/src/raft.c
+++ b/src/raft.c
@@ -144,7 +144,7 @@ static void won_elections(struct booth_config *conf_ptr,
 	time_reset(&tk->election_end);
 	tk->voted_for = NULL;
 
-	if (is_time_set(&tk->delay_commit) && all_sites_replied(tk)) {
+	if (is_time_set(&tk->delay_commit) && all_sites_replied(conf_ptr, tk)) {
 		time_reset(&tk->delay_commit);
 		tk_log_debug("reset delay commit as all sites replied");
 	}
@@ -477,7 +477,7 @@ static int process_ACK(struct booth_config *conf_ptr,
 			term == tk->current_term &&
 			leader == tk->leader) {
 
-		if (majority_of_bits(tk, tk->acks_received)) {
+		if (majority_of_bits(conf_ptr, tk, tk->acks_received)) {
 			/* OK, at least half of the nodes are reachable;
 			 * Update the ticket and send update messages out
 			 */
@@ -727,7 +727,8 @@ vote_for_sender:
 	}
 
 
-	init_ticket_msg(&omsg, OP_VOTE_FOR, OP_REQ_VOTE, RLT_SUCCESS, 0, tk);
+	init_ticket_msg(conf_ptr, &omsg, OP_VOTE_FOR, OP_REQ_VOTE,
+	                RLT_SUCCESS, 0, tk);
 	omsg.ticket.leader = htonl(get_node_id(tk->voted_for));
 	return booth_udp_send_auth(conf_ptr, sender, &omsg, sendmsglen(&omsg));
 }

--- a/src/raft.c
+++ b/src/raft.c
@@ -161,7 +161,7 @@ static int is_tie(struct ticket_config *tk)
 	int count[MAX_NODES] = { 0, };
 	int max_votes = 0, max_cnt = 0;
 
-	for(i=0; i<booth_conf->site_count; i++) {
+	for (i = 0; i < booth_conf->site_count; i++) {
 		v = tk->votes_for[i];
 		if (!v)
 			continue;
@@ -169,7 +169,7 @@ static int is_tie(struct ticket_config *tk)
 		max_votes = max(max_votes, count[v->index]);
 	}
 
-	for(i=0; i<booth_conf->site_count; i++) {
+	for (i = 0; i < booth_conf->site_count; i++) {
 		if (count[i] == max_votes)
 			max_cnt++;
 	}
@@ -183,8 +183,7 @@ static struct booth_site *majority_votes(struct ticket_config *tk)
 	struct booth_site *v;
 	int count[MAX_NODES] = { 0, };
 
-
-	for(i=0; i<booth_conf->site_count; i++) {
+	for (i = 0; i < booth_conf->site_count; i++) {
 		v = tk->votes_for[i];
 		if (!v || v == no_leader)
 			continue;

--- a/src/raft.h
+++ b/src/raft.h
@@ -20,6 +20,7 @@
 #define _RAFT_H
 
 #include "booth.h"
+#include "config.h"
 
 typedef enum {
 	ST_INIT      = CHAR2CONST('I', 'n', 'i', 't'),
@@ -30,14 +31,47 @@ typedef enum {
 
 struct ticket_config;
 
-int raft_answer(struct ticket_config *tk,
-		struct booth_site *from,
-		struct booth_site *leader,
-		struct boothc_ticket_msg *msg);
+/**
+ * @internal
+ * Core part of the dealing with obtained message per the consensus protocol
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] tk ticket at hand
+ * @param[in] from site structure of the sender
+ * @param[in] leader site structure of the assumed leader
+ * @param[in] msg message to deal with
+ *
+ * @return 0 on success or negative value (-1 or -errno) on error
+ */
+int raft_answer(struct booth_config *conf_ptr, struct ticket_config *tk,
+                struct booth_site *from, struct booth_site *leader,
+                struct boothc_ticket_msg *msg);
 
-int new_election(struct ticket_config *tk,
-		struct booth_site *new_leader, int update_term, cmd_reason_t reason);
-void elections_end(struct ticket_config *tk);
+/**
+ * @internal
+ * Jump into new election phase
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] tk ticket at hand
+ * @param[in] new_leader NULL or #local if we are the assigned leader
+ * @param[in] update_term 0 for no, yes otherwise (2 is a special
+ *                        case that there was a tie previously)
+ * @param[in] reason explains why new election is conducted
+ *
+ * @return 1 if new election was started, 0 if not for being prevented
+ */
+int new_election(struct booth_config *conf_ptr, struct ticket_config *tk,
+                 struct booth_site *new_leader, int update_term,
+                 cmd_reason_t reason);
 
+/**
+ * @internal
+ * Conclude the election phase
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] tk ticket at hand
+ */
+void elections_end(struct booth_config *conf_ptr,
+                   struct ticket_config *tk);
 
 #endif /* _RAFT_H */

--- a/src/request.c
+++ b/src/request.c
@@ -50,6 +50,7 @@ void *add_req(
 	return rp;
 }
 
+/* XXX UNUSED */
 int get_req_id(const void *rp)
 {
 	if (!rp)

--- a/src/request.c
+++ b/src/request.c
@@ -64,7 +64,8 @@ static void del_req(GList *lp)
 	req_l = g_list_delete_link(req_l, lp);
 }
 
-void foreach_tkt_req(struct ticket_config *tk, req_fp f)
+void foreach_tkt_req(struct booth_config *conf_ptr, struct ticket_config *tk,
+                     req_fp f)
 {
 	GList *lp, *next;
 	struct request *rp;
@@ -74,7 +75,7 @@ void foreach_tkt_req(struct ticket_config *tk, req_fp f)
 		next = g_list_next(lp);
 		rp = (struct request *)lp->data;
 		if (rp->tk == tk &&
-				(f)(rp->tk, rp->client_fd, rp->msg) == 0) {
+				(f)(conf_ptr, rp->tk, rp->client_fd, rp->msg) == 0) {
 			log_debug("remove request for client %d", rp->client_fd);
 			del_req(lp); /* don't need this request anymore */
 		}

--- a/src/request.h
+++ b/src/request.h
@@ -62,6 +62,8 @@ void *add_req(struct ticket_config *tk, struct client *req_client,
  */
 void foreach_tkt_req(struct booth_config *conf_ptr, struct ticket_config *tk,
                      req_fp f);
+
+/* XXX UNUSED */
 int get_req_id(const void *rp);
 
 #endif /* _REQUEST_H */

--- a/src/request.h
+++ b/src/request.h
@@ -44,12 +44,24 @@ struct request {
 	void *msg;
 };
 
-typedef int (*req_fp)(
-	struct ticket_config *, int, struct boothc_ticket_msg *);
+typedef int (*req_fp)(struct booth_config *conf_ptr, struct ticket_config *,
+                      int, struct boothc_ticket_msg *);
 
 void *add_req(struct ticket_config *tk, struct client *req_client,
 	struct boothc_ticket_msg *msg);
-void foreach_tkt_req(struct ticket_config *tk, req_fp f);
+
+/**
+ * @internal
+ * Handle all pendign requests for given ticket using function @p f
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] tk ticket at hand
+ * @param[in] f handling function
+ *
+ * @return 1 on success, 0 when not done with the message, yet
+ */
+void foreach_tkt_req(struct booth_config *conf_ptr, struct ticket_config *tk,
+                     req_fp f);
 int get_req_id(const void *rp);
 
 #endif /* _REQUEST_H */

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -628,7 +628,7 @@ void update_ticket_state(struct ticket_config *tk, struct booth_site *sender)
 	}
 }
 
-int setup_ticket(void)
+int setup_ticket(struct booth_config *conf_ptr)
 {
 	struct ticket_config *tk;
 	int i;
@@ -637,7 +637,7 @@ int setup_ticket(void)
 		reset_ticket(tk);
 
 		if (local->type == SITE) {
-			if (!pcmk_handler.load_ticket(tk)) {
+			if (!pcmk_handler.load_ticket(conf_ptr, tk)) {
 				update_ticket_state(tk, NULL);
 			}
 			tk->update_cib = 1;
@@ -1213,7 +1213,8 @@ static void update_acks(
 }
 
 /* read ticket message */
-int ticket_recv(void *buf, struct booth_site *source)
+int ticket_recv(struct booth_config *conf_ptr, void *buf,
+                struct booth_site *source)
 {
 	struct boothc_ticket_msg *msg;
 	struct ticket_config *tk;
@@ -1231,7 +1232,7 @@ int ticket_recv(void *buf, struct booth_site *source)
 
 
 	leader_u = ntohl(msg->ticket.leader);
-	if (!find_site_by_id(leader_u, &leader)) {
+	if (!find_site_by_id(conf_ptr, leader_u, &leader)) {
 		tk_log_error("message with unknown leader %u received", leader_u);
 		source->invalid_cnt++;
 		return -EINVAL;

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -274,7 +274,7 @@ static int do_ext_prog(struct booth_config *conf_ptr,
 
 	switch(tk_test.progstate) {
 	case EXTPROG_IDLE:
-		rv = run_handler(tk);
+		rv = run_handler(conf_ptr, tk);
 		if (rv == RUNCMD_ERR) {
 			tk_log_warn("couldn't run external test, not allowed to acquire ticket");
 			ext_prog_failed(conf_ptr, tk, start_election);

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -47,28 +47,6 @@
 
 extern int TIME_RES;
 
-int find_ticket_by_name(struct booth_config *conf_ptr,
-                        const char *ticket, struct ticket_config **found)
-{
-	struct ticket_config *tk;
-	int i;
-
-	assert(conf_ptr != NULL);
-
-	if (found)
-		*found = NULL;
-
-	FOREACH_TICKET(conf_ptr, i, tk) {
-		if (!strncmp(tk->name, ticket, sizeof(tk->name))) {
-			if (found)
-				*found = tk;
-			return 1;
-		}
-	}
-
-	return 0;
-}
-
 int check_ticket(struct booth_config *conf_ptr, const char *ticket,
                  struct ticket_config **found)
 {

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -839,7 +839,8 @@ int ticket_broadcast(struct booth_config *conf_ptr,
 		expect_replies(tk, expected_reply);
 	}
 	ticket_activate_timeout(tk);
-	return transport()->broadcast_auth(conf_ptr, &msg, sendmsglen(&msg));
+	return transport(conf_ptr)->broadcast_auth(conf_ptr, &msg,
+	                                           sendmsglen(&msg));
 }
 
 

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -167,9 +167,9 @@ int ticket_write(struct booth_config *conf_ptr, struct ticket_config *tk)
 				"delaying ticket grant to CIB");
 			return 1;
 		}
-		pcmk_handler.grant_ticket(tk);
+		conf_ptr->ticket_handler->grant_ticket(tk);
 	} else {
-		pcmk_handler.revoke_ticket(tk);
+		conf_ptr->ticket_handler->revoke_ticket(tk);
 	}
 	tk->update_cib = 0;
 
@@ -673,7 +673,7 @@ int setup_ticket(struct booth_config *conf_ptr)
 		reset_ticket(tk);
 
 		if (local->type == SITE) {
-			if (!pcmk_handler.load_ticket(conf_ptr, tk)) {
+			if (!conf_ptr->ticket_handler->load_ticket(conf_ptr, tk)) {
 				update_ticket_state(conf_ptr, tk, NULL);
 			}
 			tk->update_cib = 1;

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -560,6 +560,7 @@ void disown_ticket(struct ticket_config *tk)
 	get_time(&tk->term_expires);
 }
 
+/* XXX UNUSED */
 int disown_if_expired(struct ticket_config *tk)
 {
 	if (is_past(&tk->term_expires) ||
@@ -1014,7 +1015,7 @@ just_resend:
 	resend_msg(conf_ptr, tk);
 }
 
-int postpone_ticket_processing(struct ticket_config *tk)
+static int postpone_ticket_processing(struct ticket_config *tk)
 {
 	extern timetype start_time;
 

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -64,7 +64,7 @@ int find_ticket_by_name(const char *ticket, struct ticket_config **found)
 	if (found)
 		*found = NULL;
 
-	foreach_ticket(i, tk) {
+	FOREACH_TICKET(i, tk) {
 		if (!strncmp(tk->name, ticket, sizeof(tk->name))) {
 			if (found)
 				*found = tk;
@@ -404,7 +404,7 @@ int list_ticket(char **pdata, unsigned int *len)
 
 	alloc = booth_conf->ticket_count * (BOOTH_NAME_LEN * 2 + 128 + 16);
 
-	foreach_ticket(i, tk) {
+	FOREACH_TICKET(i, tk) {
 		multiple_grant_warning_length = number_sites_marked_as_granted(tk);
 
 		if (multiple_grant_warning_length > 1) {
@@ -418,7 +418,7 @@ int list_ticket(char **pdata, unsigned int *len)
 		return -ENOMEM;
 
 	cp = data;
-	foreach_ticket(i, tk) {
+	FOREACH_TICKET(i, tk) {
 		if ((!is_manual(tk)) && is_time_set(&tk->term_expires)) {
 			/* Manual tickets doesn't have term_expires defined */
 			ts = wall_ts(&tk->term_expires);
@@ -466,7 +466,7 @@ int list_ticket(char **pdata, unsigned int *len)
 		}
 	}
 
-	foreach_ticket(i, tk) {
+	FOREACH_TICKET(i, tk) {
 		multiple_grant_warning_length = number_sites_marked_as_granted(tk);
 
 		if (multiple_grant_warning_length > 1) {
@@ -475,7 +475,7 @@ int list_ticket(char **pdata, unsigned int *len)
 					"\nWARNING: The ticket %s is granted to multiple sites: ",  // ~55 characters
 					tk->name);
 
-			foreach_node(site_index, site) {
+			FOREACH_NODE(site_index, site) {
 				if (tk->sites_where_granted[site_index] > 0) {
 					cp += snprintf(cp,
 						alloc - (cp - data),
@@ -631,7 +631,7 @@ int setup_ticket(void)
 	struct ticket_config *tk;
 	int i;
 
-	foreach_ticket(i, tk) {
+	FOREACH_TICKET(i, tk) {
 		reset_ticket(tk);
 
 		if (local->type == SITE) {
@@ -858,7 +858,7 @@ static void log_lost_servers(struct ticket_config *tk)
 		 */
 		return;
 
-	foreach_node(i, n) {
+	FOREACH_NODE(i, n) {
 		if (!(tk->acks_received & n->bitmask)) {
 			tk_log_warn("%s %s didn't acknowledge our %s, "
 			"will retry %d times",
@@ -878,7 +878,7 @@ static void resend_msg(struct ticket_config *tk)
 	if (!(tk->acks_received ^ local->bitmask)) {
 		ticket_broadcast(tk, tk->last_request, 0, RLT_SUCCESS, 0);
 	} else {
-		foreach_node(i, n) {
+		FOREACH_NODE(i, n) {
 			if (!(tk->acks_received & n->bitmask)) {
 				n->resend_cnt++;
 				tk_log_debug("resending %s to %s",
@@ -1142,7 +1142,7 @@ void process_tickets(void)
 	int i;
 	timetype last_cron;
 
-	foreach_ticket(i, tk) {
+	FOREACH_TICKET(i, tk) {
 		if (!has_extprog_exited(tk) &&
 				is_time_set(&tk->next_cron) && !is_past(&tk->next_cron))
 			continue;
@@ -1166,7 +1166,7 @@ void tickets_log_info(void)
 	int i;
 	time_t ts;
 
-	foreach_ticket(i, tk) {
+	FOREACH_TICKET(i, tk) {
 		ts = wall_ts(&tk->term_expires);
 		tk_log_info("state '%s' "
 				"term %d "
@@ -1364,7 +1364,7 @@ int number_sites_marked_as_granted(struct ticket_config *tk)
 	int i, result = 0;
 	struct booth_site *ignored __attribute__((unused));
 
-	foreach_node(i, ignored) {
+	FOREACH_NODE(i, ignored) {
 		result += tk->sites_where_granted[i];
 	}
 

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -87,14 +87,16 @@ int check_ticket(char *ticket, struct ticket_config **found)
 	return find_ticket_by_name(ticket, found);
 }
 
-int check_site(char *site, int *is_local)
+/* XXX UNUSED */
+int check_site(struct booth_config *conf_ptr, const char *site,
+               int *is_local)
 {
 	struct booth_site *node;
 
 	if (!check_max_len_valid(site, sizeof(node->addr_string)))
 		return 0;
 
-	if (find_site_by_name(site, &node, 0)) {
+	if (find_site_by_name(conf_ptr, site, &node, 0)) {
 		*is_local = node->local;
 		return 1;
 	}

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -31,30 +31,21 @@
 #else
 #include "alt/range2random_glib.h"
 #endif
-#include "ticket.h"
+#include "booth.h"
 #include "config.h"
-#include "pacemaker.h"
+#include "handler.h"
 #include "inline-fn.h"
 #include "log.h"
-#include "booth.h"
-#include "raft.h"
-#include "handler.h"
-#include "request.h"
 #include "manual.h"
+#include "pacemaker.h"
+#include "raft.h"
+#include "request.h"
+#include "ticket.h"
+#include "utils.h"
 
 #define TK_LINE			256
 
 extern int TIME_RES;
-
-/* Untrusted input, must fit (incl. \0) in a buffer of max chars. */
-int check_max_len_valid(const char *s, int max)
-{
-	int i;
-	for(i=0; i<max; i++)
-		if (s[i] == 0)
-			return 1;
-	return 0;
-}
 
 int find_ticket_by_name(struct booth_config *conf_ptr,
                         const char *ticket, struct ticket_config **found)

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -35,8 +35,15 @@ extern int TIME_RES;
 #define DEFAULT_RETRIES			10
 
 
-#define foreach_ticket(i_,t_) for(i_=0; (t_=booth_conf->ticket+i_, i_<booth_conf->ticket_count); i_++)
-#define foreach_node(i_,n_) for(i_=0; (n_=booth_conf->site+i_, i_<booth_conf->site_count); i_++)
+#define foreach_ticket(i_, t_) \
+	for (i_ = 0; \
+	     (t_ = booth_conf->ticket + i_, i_ < booth_conf->ticket_count); \
+	     i_++)
+
+#define foreach_node(i_, n_) \
+	for (i_ = 0; \
+	     (n_ = booth_conf->site + i_, i_ < booth_conf->site_count); \
+	     i_++)
 
 #define set_leader(tk, who) do { \
 	if (who == NULL) { \

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -166,19 +166,6 @@ int setup_ticket(struct booth_config *conf_ptr);
 
 /**
  * @internal
- * Pick a ticket structure based on given name
- *
- * @param[inout] conf_ptr config object to refer to
- * @param[in] ticket name of the ticket to search for
- * @param[out] found place the reference here when found
- *
- * @return see @list_ticket and @send_header_plus
- */
-int find_ticket_by_name(struct booth_config *conf_ptr,
-                        const char *ticket, struct ticket_config **found);
-
-/**
- * @internal
  * Apply the next step with the ticket if possible.
  *
  * @param[inout] conf_ptr config object to refer to

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -236,12 +236,44 @@ void process_tickets(struct booth_config *conf_ptr);
 void tickets_log_info(struct booth_config *conf_ptr);
 
 char *state_to_string(uint32_t state_ho);
-int send_reject(struct booth_site *dest, struct ticket_config *tk,
-	cmd_result_t code, struct boothc_ticket_msg *in_msg);
-int send_msg (int cmd, struct ticket_config *tk,
-	struct booth_site *dest, struct boothc_ticket_msg *in_msg);
-int notify_client(struct ticket_config *tk, int client_fd,
-	struct boothc_ticket_msg *msg);
+
+/**
+ * @internal
+ * For a given ticket and recipient site, send a rejection
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] dest site structure of the recipient
+ * @param[in] tk ticket at hand
+ * @param[in] code further detail for the rejection
+ * @param[in] in_msg message this is going to be a response to
+ */
+int send_reject(struct booth_config *conf_ptr, struct booth_site *dest,
+                struct ticket_config *tk, cmd_result_t code,
+                struct boothc_ticket_msg *in_msg);
+
+/**
+ * @internal
+ * For a given ticket, recipient site and possibly its message, send a response
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] cmd what type of message is to be sent
+ * @param[in] dest site structure of the recipient
+ * @param[in] in_msg message this is going to be a response to
+ */
+int send_msg(struct booth_config *conf_ptr, int cmd, struct ticket_config *tk,
+             struct booth_site *dest, struct boothc_ticket_msg *in_msg);
+
+/**
+ * @internal
+ * Notify client at particular socket, regarding particular ticket
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] tk ticket at hand
+ * @param[in] fd file descriptor of the socket to respond to
+ * @param[in] msg input message being responded to
+ */
+int notify_client(struct booth_config *conf_ptr, struct ticket_config *tk,
+                  int client_fd, struct boothc_ticket_msg *msg);
 
 /**
  * @internal

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -117,11 +117,33 @@ int grant_ticket(struct ticket_config *ticket);
 int revoke_ticket(struct ticket_config *ticket);
 int list_ticket(char **pdata, unsigned int *len);
 
-int ticket_recv(void *buf, struct booth_site *source);
+/**
+ * @internal
+ * Second stage of incoming datagram handling (after authentication)
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] buf raw message to act upon
+ * @param[in] source member originating this message
+ *
+ * @return 0 on success or negative value (-1 or -errno) on error
+ */
+int ticket_recv(struct booth_config *conf_ptr, void *buf,
+                struct booth_site *source);
+
 void reset_ticket(struct ticket_config *tk);
 void reset_ticket_and_set_no_leader(struct ticket_config *tk);
 void update_ticket_state(struct ticket_config *tk, struct booth_site *sender);
-int setup_ticket(void);
+
+/**
+ * @internal
+ * Initial "consult local pacemaker and booth peers" inquiries
+ *
+ * @param[inout] conf_ptr config object to use as a starting point
+ *
+ * @return 0 (for the time being)
+ */
+int setup_ticket(struct booth_config *conf_ptr);
+
 int check_max_len_valid(const char *s, int max);
 
 int do_grant_ticket(struct ticket_config *ticket, int options);

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -180,7 +180,16 @@ int check_max_len_valid(const char *s, int max);
 int find_ticket_by_name(struct booth_config *conf_ptr,
                         const char *ticket, struct ticket_config **found);
 
-void set_ticket_wakeup(struct ticket_config *tk);
+/**
+ * @internal
+ * Apply the next step with the ticket if possible.
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] tk ticket at hand
+ */
+void set_ticket_wakeup(struct booth_config *conf_ptr,
+                       struct ticket_config *tk);
+
 int postpone_ticket_processing(struct ticket_config *tk);
 
 /**
@@ -304,7 +313,17 @@ int leader_update_ticket(struct booth_config *conf_ptr,
                          struct ticket_config *tk);
 
 void add_random_delay(struct ticket_config *tk);
-void schedule_election(struct ticket_config *tk, cmd_reason_t reason);
+
+/**
+ * @internal
+ * Make it so the nearest ticket swipe will start election
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] tk ticket at hand
+ * @param[in] reason explains why new election is conducted
+ */
+void schedule_election(struct booth_config *conf_ptr, struct ticket_config *tk,
+                       cmd_reason_t reason);
 
 int is_manual(struct ticket_config *tk);
 

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -275,7 +275,6 @@ void add_random_delay(struct ticket_config *tk);
 void schedule_election(struct ticket_config *tk, cmd_reason_t reason);
 
 int is_manual(struct ticket_config *tk);
-int number_sites_marked_as_granted(struct ticket_config *tk);
 
 int check_attr_prereq(struct ticket_config *tk, grant_type_e grant_type);
 

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -164,8 +164,6 @@ void update_ticket_state(struct booth_config *conf_ptr,
  */
 int setup_ticket(struct booth_config *conf_ptr);
 
-int check_max_len_valid(const char *s, int max);
-
 /**
  * @internal
  * Pick a ticket structure based on given name

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -95,6 +95,8 @@ extern int TIME_RES;
 
 void save_committed_tkt(struct ticket_config *tk);
 void disown_ticket(struct ticket_config *tk);
+
+/* XXX UNUSED */
 int disown_if_expired(struct ticket_config *tk);
 
 /**
@@ -124,9 +126,6 @@ int check_ticket(struct booth_config *conf_ptr, const char *ticket,
  */
 int check_site(struct booth_config *conf_ptr, const char *site,
                int *local);
-
-int grant_ticket(struct ticket_config *ticket);
-int revoke_ticket(struct ticket_config *ticket);
 
 /**
  * @internal
@@ -189,8 +188,6 @@ int find_ticket_by_name(struct booth_config *conf_ptr,
  */
 void set_ticket_wakeup(struct booth_config *conf_ptr,
                        struct ticket_config *tk);
-
-int postpone_ticket_processing(struct ticket_config *tk);
 
 /**
  * @internal

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -96,7 +96,19 @@ extern int TIME_RES;
 void save_committed_tkt(struct ticket_config *tk);
 void disown_ticket(struct ticket_config *tk);
 int disown_if_expired(struct ticket_config *tk);
-int check_ticket(char *ticket, struct ticket_config **tc);
+
+/**
+ * @internal
+ * Pick a ticket structure based on given name, with some apriori sanity checks
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] ticket name of the ticket to search for
+ * @param[out] found place the reference here when found
+ *
+ * @return 0 on failure, see @find_ticket_by_name otherwise
+ */
+int check_ticket(struct booth_config *conf_ptr, const char *ticket,
+                 struct ticket_config **tc);
 
 /**
  * @internal
@@ -155,7 +167,18 @@ int setup_ticket(struct booth_config *conf_ptr);
 
 int check_max_len_valid(const char *s, int max);
 
-int find_ticket_by_name(const char *ticket, struct ticket_config **found);
+/**
+ * @internal
+ * Pick a ticket structure based on given name
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] ticket name of the ticket to search for
+ * @param[out] found place the reference here when found
+ *
+ * @return see @list_ticket and @send_header_plus
+ */
+int find_ticket_by_name(struct booth_config *conf_ptr,
+                        const char *ticket, struct ticket_config **found);
 
 void set_ticket_wakeup(struct ticket_config *tk);
 int postpone_ticket_processing(struct ticket_config *tk);

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -35,12 +35,12 @@ extern int TIME_RES;
 #define DEFAULT_RETRIES			10
 
 
-#define foreach_ticket(i_, t_) \
+#define FOREACH_TICKET(i_, t_) \
 	for (i_ = 0; \
 	     (t_ = booth_conf->ticket + i_, i_ < booth_conf->ticket_count); \
 	     i_++)
 
-#define foreach_node(i_, n_) \
+#define FOREACH_NODE(i_, n_) \
 	for (i_ = 0; \
 	     (n_ = booth_conf->site + i_, i_ < booth_conf->site_count); \
 	     i_++)

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -97,7 +97,22 @@ void save_committed_tkt(struct ticket_config *tk);
 void disown_ticket(struct ticket_config *tk);
 int disown_if_expired(struct ticket_config *tk);
 int check_ticket(char *ticket, struct ticket_config **tc);
-int check_site(char *site, int *local);
+
+/**
+ * @internal
+ * Check whether given site is valid
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] site which member to look for
+ * @param[out] is_local store whether the member is local on success
+ *
+ * @note XXX UNUSED
+ *
+ * @return 1 on success (found and valid), 0 otherwise
+ */
+int check_site(struct booth_config *conf_ptr, const char *site,
+               int *local);
+
 int grant_ticket(struct ticket_config *ticket);
 int revoke_ticket(struct ticket_config *ticket);
 int list_ticket(char **pdata, unsigned int *len);

--- a/src/transport.c
+++ b/src/transport.c
@@ -884,7 +884,7 @@ static int booth_udp_broadcast_auth(void *buf, int len)
 		return rv;
 
 	rvs = 0;
-	foreach_node(i, site) {
+	FOREACH_NODE(i, site) {
 		if (site != local) {
 			rv = booth_udp_send(site, buf, len);
 			if (!rvs)

--- a/src/transport.c
+++ b/src/transport.c
@@ -77,11 +77,10 @@ enum match_type {
 	EXACT_MATCH,
 };
 
-static int find_address(unsigned char ipaddr[BOOTH_IPADDR_LEN],
-		int family, int prefixlen,
-		int fuzzy_allowed,
-		struct booth_site **me,
-		int *address_bits_matched)
+static int find_address(struct booth_config *conf_ptr,
+                        unsigned char ipaddr[BOOTH_IPADDR_LEN],
+                        int family, int prefixlen, int fuzzy_allowed,
+                        struct booth_site **me, int *address_bits_matched)
 {
 	int i;
 	struct booth_site *node;
@@ -91,14 +90,15 @@ static int find_address(unsigned char ipaddr[BOOTH_IPADDR_LEN],
 	int matched;
 	enum match_type did_match = NO_MATCH;
 
+	assert(conf_ptr != NULL);
 
 	bytes = prefixlen / 8;
 	bits_left = prefixlen % 8;
 	/* One bit left to check means ignore 7 lowest bits. */
 	mask = ~( (1 << (8 - bits_left)) -1);
 
-	for (i = 0; i < booth_conf->site_count; i++) {
-		node = booth_conf->site + i;
+	for (i = 0; i < conf_ptr->site_count; i++) {
+		node = conf_ptr->site + i;
 		if (family != node->family)
 			continue;
 		n_a = node_to_addr_pointer(node);
@@ -140,8 +140,8 @@ static int find_address(unsigned char ipaddr[BOOTH_IPADDR_LEN],
 }
 
 
-int _find_myself(int family, struct booth_site **mep, int fuzzy_allowed);
-int _find_myself(int family, struct booth_site **mep, int fuzzy_allowed)
+static int _find_myself(struct booth_config *conf_ptr, int family,
+                        struct booth_site **mep, int fuzzy_allowed)
 {
 	int fd;
 	struct sockaddr_nl nladdr;
@@ -244,9 +244,9 @@ int _find_myself(int family, struct booth_site **mep, int fuzzy_allowed)
 				 * the function find_address will try to return another, most similar
 				 * address (with the longest possible number of same bytes). */
 				if (ifa->ifa_prefixlen > address_bits_matched) {
-					find_address(ipaddr,
-							ifa->ifa_family, ifa->ifa_prefixlen,
-							fuzzy_allowed, &me, &address_bits_matched);
+					find_address(conf_ptr, ipaddr,
+					             ifa->ifa_family, ifa->ifa_prefixlen,
+					             fuzzy_allowed, &me, &address_bits_matched);
 
 					if (me) {
 						log_debug("found myself at %s (%d bits matched)",
@@ -260,9 +260,9 @@ int _find_myself(int family, struct booth_site **mep, int fuzzy_allowed)
 				 * call the function find_address with disabled searching of
 				 * similar addresses (fuzzy_allowed == 0) */
 				else if (ifa->ifa_prefixlen == address_bits_matched) {
-					find_address(ipaddr,
-							ifa->ifa_family, ifa->ifa_prefixlen,
-							0 /* fuzzy_allowed */, &me, &address_bits_matched);
+					find_address(conf_ptr, ipaddr,
+					             ifa->ifa_family, ifa->ifa_prefixlen,
+					             0 /* fuzzy_allowed */, &me, &address_bits_matched);
 
 					if (me) {
 						log_debug("found myself at %s (exact match)",
@@ -287,10 +287,11 @@ found:
 	return 1;
 }
 
-int find_myself(struct booth_site **mep, int fuzzy_allowed)
+int find_myself(struct booth_config *conf_ptr, struct booth_site **mep,
+                int fuzzy_allowed)
 {
-	return _find_myself(AF_INET6, mep, fuzzy_allowed) ||
-		_find_myself(AF_INET, mep, fuzzy_allowed);
+	return _find_myself(conf_ptr, AF_INET6, mep, fuzzy_allowed) ||
+		_find_myself(conf_ptr, AF_INET, mep, fuzzy_allowed);
 }
 
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -361,9 +361,8 @@ retry:
 	return 0;
 }
 
-
 /* Only used for client requests (tcp) */
-int read_client(struct client *req_cl)
+static int read_client(struct client *req_cl)
 {
 	char *msg;
 	struct boothc_header *header;
@@ -412,7 +411,6 @@ int read_client(struct client *req_cl)
 
 	return 0;
 }
-
 
 /* Only used for client requests (tcp) */
 static void process_connection(struct booth_config *conf_ptr, int ci)

--- a/src/transport.c
+++ b/src/transport.c
@@ -490,7 +490,8 @@ static void process_connection(struct booth_config *conf_ptr, int ci)
 	return;
 
 send_err:
-	init_header(&err_reply.header, CL_RESULT, 0, 0, errc, 0, sizeof(err_reply));
+	init_header(conf_ptr, &err_reply.header, CL_RESULT, 0, 0, errc, 0,
+	            sizeof(err_reply));
 	send_client_msg(conf_ptr, req_cl->fd, &err_reply);
 
 kill:
@@ -686,7 +687,7 @@ static int add_hmac(struct booth_config *conf_ptr, void *data, int len)
 
 	assert(conf_ptr != NULL);
 
-	if (!is_auth_req())
+	if (!is_auth_req(conf_ptr))
 		return 0;
 
 	payload_len = len - sizeof(struct hmac);
@@ -739,7 +740,7 @@ static int booth_tcp_recv_auth(struct booth_config *conf_ptr,
 		return got;
 	}
 	total = got;
-	if (is_auth_req()) {
+	if (is_auth_req(conf_ptr)) {
 		got = booth_tcp_recv(from, (unsigned char *)buf+payload_len, sizeof(struct hmac));
 		if (got != sizeof(struct hmac)
 				|| check_auth(conf_ptr, from, buf, len)) {
@@ -1055,10 +1056,10 @@ int check_auth(struct booth_config *conf_ptr, struct booth_site *from,
 	int payload_len;
 	struct hmac *hp;
 
-	if (!is_auth_req())
-		return 0;
-
 	assert(conf_ptr != NULL);
+
+	if (!is_auth_req(conf_ptr))
+		return 0;
 
 	payload_len = len - sizeof(struct hmac);
 	if (payload_len < 0) {

--- a/src/transport.c
+++ b/src/transport.c
@@ -474,7 +474,7 @@ static void process_connection(struct booth_config *conf_ptr, int ci)
 	case ATTR_GET:
 	case ATTR_SET:
 	case ATTR_DEL:
-		if (process_attr_request(req_cl, msg) == 1)
+		if (process_attr_request(conf_ptr, req_cl, msg) == 1)
 			goto kill; /* request processed definitely, close connection */
 		else
 			return;
@@ -1124,7 +1124,7 @@ int message_recv(struct booth_config *conf_ptr, void *msg, int msglen)
 		/* not used, clients send/retrieve attributes directly
 		 * from sites
 		 */
-		return attr_recv(msg, source);
+		return attr_recv(conf_ptr, msg, source);
 	} else {
 		return ticket_recv(conf_ptr, msg, source);
 	}

--- a/src/transport.c
+++ b/src/transport.c
@@ -33,14 +33,14 @@
 #include <netinet/tcp.h>
 #include <sys/socket.h>  /* getnameinfo */
 #include "b_config.h"
+#include "config.h"
+#include "transport.h"
 #include "attr.h"
 #include "auth.h"
 #include "booth.h"
-#include "config.h"
 #include "inline-fn.h"
 #include "log.h"
 #include "ticket.h"
-#include "transport.h"
 
 #define BOOTH_IPADDR_LEN	(sizeof(struct in6_addr))
 
@@ -1089,7 +1089,7 @@ int send_header_plus(int fd, struct boothc_hdr_msg *msg, void *data, int len)
 }
 
 /* UDP message receiver (see also deliver_fn declaration's comment) */
-int message_recv(void *msg, int msglen)
+int message_recv(struct booth_config *conf_ptr, void *msg, int msglen)
 {
 	uint32_t from;
 	struct boothc_header *header;
@@ -1098,7 +1098,7 @@ int message_recv(void *msg, int msglen)
 	header = (struct boothc_header *)msg;
 
 	from = ntohl(header->from);
-	if (!find_site_by_id(from, &source)) {
+	if (!find_site_by_id(conf_ptr, from, &source)) {
 		/* caller knows the actual source address, pass
 		   the (assuredly) positive number and let it report */
 		from = from ? from : ~from;  /* avoid 0 (success) */
@@ -1126,6 +1126,6 @@ int message_recv(void *msg, int msglen)
 		 */
 		return attr_recv(msg, source);
 	} else {
-		return ticket_recv(msg, source);
+		return ticket_recv(conf_ptr, msg, source);
 	}
 }

--- a/src/transport.c
+++ b/src/transport.c
@@ -764,8 +764,8 @@ static int setup_udp_server(void)
 
 	if (rv == -1) {
 		log_error("failed to bind UDP socket to [%s]:%d: %s",
-				site_string(local), booth_conf->port,
-				strerror(errno));
+		          site_string(local), site_port(local),
+		          strerror(errno));
 		goto ex;
 	}
 

--- a/src/transport.h
+++ b/src/transport.h
@@ -47,8 +47,8 @@ struct booth_transport {
 	const char *name;
 	int (*init) (void *);
 	int (*open) (struct booth_site *);
-	int (*send) (struct booth_site *, void *, int);
-	int (*send_auth) (struct booth_site *, void *, int);
+	int (*send) (struct booth_config *, struct booth_site *, void *, int);
+	int (*send_auth) (struct booth_config *, struct booth_site *, void *, int);
 	int (*recv) (struct booth_site *, void *, int);
 	int (*recv_auth) (struct booth_site *, void *, int);
 	int (*broadcast) (void *, int);
@@ -76,11 +76,20 @@ int read_client(struct client *req_cl);
 int check_boothc_header(struct boothc_header *data, int len_incl_data);
 
 int setup_tcp_listener(int test_only);
-int booth_udp_send(struct booth_site *to, void *buf, int len);
-int booth_udp_send_auth(struct booth_site *to, void *buf, int len);
 
-int booth_tcp_open(struct booth_site *to);
-int booth_tcp_send(struct booth_site *to, void *buf, int len);
+/**
+ * @internal
+ * Send data, with authentication added
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] to site structure of the recipient
+ * @param[in] buf message itself
+ * @param[in] len lenght of #buf
+ *
+ * @return see @add_hmac and @booth_udp_send
+ */
+int booth_udp_send_auth(struct booth_config *conf_ptr, struct booth_site *to,
+                        void *buf, int len);
 
 /**
  * @internal
@@ -102,11 +111,36 @@ inline static void * node_to_addr_pointer(struct booth_site *node) {
 	return NULL;
 }
 
-int send_data(int fd, void *data, int datalen);
-int send_header_plus(int fd, struct boothc_hdr_msg *hdr, void *data, int len);
-#define send_client_msg(fd, msg) send_data(fd, msg, sendmsglen(msg))
+/**
+ * @internal
+ * Send data, with authentication added
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] fd descriptor of the socket to respond to
+ * @param[in] data message itself
+ * @param[in] datalen lenght of #data
+ *
+ * @return 0 on success or negative value (-1 or -errno) on error
+ */
+int send_data(struct booth_config *conf_ptr, int fd, void *data, int datalen);
 
-int add_hmac(void *data, int len);
+/**
+ * @internal
+ * First stage of incoming datagram handling (authentication)
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] fd descriptor of the socket to respond to
+ * @param[in] hdr message header
+ * @param[in] data message itself
+ * @param[in] len lengh of @data
+ *
+ * @return see #send_data and #do_write
+ */
+int send_header_plus(struct booth_config *conf_ptr, int fd,
+                     struct boothc_hdr_msg *hdr, void *data, int len);
+
+#define send_client_msg(bc, fd, msg) send_data(bc, fd, msg, sendmsglen(msg))
+
 int check_auth(struct booth_site *from, void *buf, int len);
 
 #endif /* _TRANSPORT_H */

--- a/src/transport.h
+++ b/src/transport.h
@@ -45,7 +45,7 @@ typedef enum {
 
 struct booth_transport {
 	const char *name;
-	int (*init) (void *);
+	int (*init) (struct booth_config *, void *);
 	int (*open) (struct booth_site *);
 	int (*send) (struct booth_config *, struct booth_site *, void *, int);
 	int (*send_auth) (struct booth_config *, struct booth_site *, void *, int);
@@ -57,7 +57,7 @@ struct booth_transport {
 	int (*exit) (void);
 };
 
-extern const struct booth_transport booth_transport[TRANSPORT_ENTRIES];
+typedef struct booth_transport booth_transport_table_t[TRANSPORT_ENTRIES];
 
 /**
  * @internal

--- a/src/transport.h
+++ b/src/transport.h
@@ -64,18 +64,25 @@ typedef struct booth_transport booth_transport_table_t[TRANSPORT_ENTRIES];
  * Attempts to pick identity of self from config-tracked enumeration of sites
  *
  * @param[inout] conf_ptr config object to refer to
- * @param[out] mep when self-discovery successful, site pointer is stored here
  * @param[in] fuzzy_allowed whether it's OK to approximate the match
  *
  * @return 0 on success or negative value (-1 or -errno) on error
  */
-int find_myself(struct booth_config *conf_ptr, struct booth_site **mep,
-                int fuzzy_allowed);
+int find_myself(struct booth_config *conf_ptr, int fuzzy_allowed);
 
 int read_client(struct client *req_cl);
 int check_boothc_header(struct boothc_header *data, int len_incl_data);
 
-int setup_tcp_listener(int test_only);
+/**
+ * @internal
+ * Setup the TCP listener/server
+ *
+ * @param[in] local thix verysite
+ * @param[in] test_only whether to just check if binding is clear
+ *
+ * @return 0 on success or -1 or errno on error
+ */
+int setup_tcp_listener(struct booth_site *local, int test_only);
 
 /**
  * @internal

--- a/src/transport.h
+++ b/src/transport.h
@@ -58,7 +58,19 @@ struct booth_transport {
 };
 
 extern const struct booth_transport booth_transport[TRANSPORT_ENTRIES];
-int find_myself(struct booth_site **me, int fuzzy_allowed);
+
+/**
+ * @internal
+ * Attempts to pick identity of self from config-tracked enumeration of sites
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[out] mep when self-discovery successful, site pointer is stored here
+ * @param[in] fuzzy_allowed whether it's OK to approximate the match
+ *
+ * @return 0 on success or negative value (-1 or -errno) on error
+ */
+int find_myself(struct booth_config *conf_ptr, struct booth_site **mep,
+                int fuzzy_allowed);
 
 int read_client(struct client *req_cl);
 int check_boothc_header(struct boothc_header *data, int len_incl_data);

--- a/src/transport.h
+++ b/src/transport.h
@@ -50,7 +50,7 @@ struct booth_transport {
 	int (*send) (struct booth_config *, struct booth_site *, void *, int);
 	int (*send_auth) (struct booth_config *, struct booth_site *, void *, int);
 	int (*recv) (struct booth_site *, void *, int);
-	int (*recv_auth) (struct booth_site *, void *, int);
+	int (*recv_auth) (struct booth_config *, struct booth_site *, void *, int);
 	int (*broadcast) (void *, int);
 	int (*broadcast_auth) (struct booth_config *, void *, int);
 	int (*close) (struct booth_site *);
@@ -141,6 +141,18 @@ int send_header_plus(struct booth_config *conf_ptr, int fd,
 
 #define send_client_msg(bc, fd, msg) send_data(bc, fd, msg, sendmsglen(msg))
 
-int check_auth(struct booth_site *from, void *buf, int len);
+/**
+ * @internal
+ * First stage of incoming datagram handling (authentication)
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] from site structure of the sender
+ * @param[in] buf message to check
+ * @param[in] len lengh of @buf
+ *
+ * @return see #send_data and #do_write
+ */
+int check_auth(struct booth_config *conf_ptr, struct booth_site *from,
+               void *buf, int len);
 
 #endif /* _TRANSPORT_H */

--- a/src/transport.h
+++ b/src/transport.h
@@ -52,7 +52,7 @@ struct booth_transport {
 	int (*recv) (struct booth_site *, void *, int);
 	int (*recv_auth) (struct booth_site *, void *, int);
 	int (*broadcast) (void *, int);
-	int (*broadcast_auth) (void *, int);
+	int (*broadcast_auth) (struct booth_config *, void *, int);
 	int (*close) (struct booth_site *);
 	int (*exit) (void);
 };

--- a/src/transport.h
+++ b/src/transport.h
@@ -70,7 +70,17 @@ int booth_udp_send_auth(struct booth_site *to, void *buf, int len);
 int booth_tcp_open(struct booth_site *to);
 int booth_tcp_send(struct booth_site *to, void *buf, int len);
 
-int message_recv(void *msg, int msglen);
+/**
+ * @internal
+ * First stage of incoming datagram handling (authentication)
+ *
+ * @param[inout] conf_ptr config object to refer to
+ * @param[in] msg raw message to act upon
+ * @param[in] msglen lenght of #msg
+ *
+ * @return 0 on success or negative value (-1 or -errno) on error
+ */
+int message_recv(struct booth_config *conf_ptr, void *msg, int msglen);
 
 inline static void * node_to_addr_pointer(struct booth_site *node) {
 	switch (node->family) {

--- a/src/transport.h
+++ b/src/transport.h
@@ -70,7 +70,6 @@ typedef struct booth_transport booth_transport_table_t[TRANSPORT_ENTRIES];
  */
 int find_myself(struct booth_config *conf_ptr, int fuzzy_allowed);
 
-int read_client(struct client *req_cl);
 int check_boothc_header(struct boothc_header *data, int len_incl_data);
 
 /**

--- a/src/utils.c
+++ b/src/utils.c
@@ -11,6 +11,14 @@
 #include <stdlib.h>  /* fprintf */
 #include <string.h>  /* strlen, strncpy */
 
+int check_max_len_valid(const char *s, size_t max)
+{
+	for (size_t i = 0; i < max; i++)
+		if (s[i] == '\0')
+			return 1;
+	return 0;
+}
+
 void safe_copy(char *dest, const char *value, size_t buflen,
                const char *description)
 {

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2011 Jiaju Zhang <jjzhang@suse.de>
+ * Copyright (C) 2013-2014 Philipp Marek <philipp.marek@linbit.com>
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "utils.h"
+
+#include <stdio.h>  /* EXIT_FAILURE */
+#include <stdlib.h>  /* fprintf */
+#include <string.h>  /* strlen, strncpy */
+
+void safe_copy(char *dest, const char *value, size_t buflen,
+               const char *description)
+{
+	int content_len = buflen - 1;
+
+	if (strlen(value) >= content_len) {
+		fprintf(stderr, "'%s' exceeds maximum %s length of %d\n",
+			value, description, content_len);
+		exit(EXIT_FAILURE);
+	}
+	strncpy(dest, value, content_len);
+	dest[content_len] = 0;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -11,6 +11,17 @@
 
 /**
  * @internal
+ * For an untrusted string, check that it terminates in @p max initial bytes
+ *
+ * @param[in] s string at input
+ * @param[in] max delimits the termination seeking this big initial chunk
+ *
+ * @return 1 if early termination satisified, 0 if not
+ */
+int check_max_len_valid(const char *s, size_t max);
+
+/**
+ * @internal
  * Like strncpy, but with explicit protection and better diagnostics
  *
  * @param[out] dest where to copy the string to

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2011 Jiaju Zhang <jjzhang@suse.de>
+ * Copyright (C) 2013-2014 Philipp Marek <philipp.marek@linbit.com>
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <stdlib.h>  /* size_t */
+
+/**
+ * @internal
+ * Like strncpy, but with explicit protection and better diagnostics
+ *
+ * @param[out] dest where to copy the string to
+ * @param[in] value where to copy the string from
+ * @param[in] buflen nmaximum size of #dest (incl. trailing '\0', or sizeof)
+ * @param[in] description how to refer to the target as
+ *
+ * @return number of clients tracked (incl. this one)
+ */
+void safe_copy(char *dest, const char *value, size_t buflen,
+               const char *description);


### PR DESCRIPTION
This is a first step in a direction towards less rigid/cumbersome
code, easing the understandability and maintenance as such.

Get rid of (some, commonly shared) global variables means:

- less hidden, behind the curtains state, meaning less
  of surprising side-effects, better understandable data
  flow, effectively containing the impact radius of the
  functions

- unit tests are more feasible (easier to conduct) when the
  inputs to the computation/functions are not part of said
  non-apparent global state, but rather part of the explicit
  input to the them

- likewise, any "scope of authority" etc. types of regrouping
  of the functions in modules is not easily done when the
  data flow is partially obfuscated

- more dynamic handling is enabled (e.g. multithreading or
  fetching a new instance of the configuration, which can then
  be conditionally promoted to the life configuration)
  if there's a good need for that

- last but not least, using global-scoped variables is not
  considered a praised practice

For `struct booth_config` in particular, it was dynamically
alloc'd at heap, so there was no gain in terms of avoiding
relevant class of bugs.

Also, this PR reconciles the no-code-doc problem at the functions
being touched throughout.  And this swipe helped to identify
both unused and needlessly exported functions.
