### PR TITLE
Fix gcc-10 warnings for multiple definition of pcmk_handler

### DIFF
--- a/src/pacemaker.h
+++ b/src/pacemaker.h
@@ -32,7 +32,7 @@ struct ticket_handler {
 	int (*del_attr) (struct ticket_config *tk, const char *a);
 };
 
-struct ticket_handler pcmk_handler;
+extern struct ticket_handler pcmk_handler;
 const char * interpret_rv(int rv);
 
 


### PR DESCRIPTION
/usr/bin/ld: boothd-ticket.o:./src/pacemaker.h:35: multiple definition of `pcmk_handler'; boothd-main.o:./src/pacemaker.h:35: first defined here
/usr/bin/ld: boothd-pacemaker.o:./src/pacemaker.h:35: multiple definition of `pcmk_handler'; boothd-main.o:./src/pacemaker.h:35: first defined here
/usr/bin/ld: boothd-handler.o:./src/pacemaker.h:35: multiple definition of `pcmk_handler'; boothd-main.o:./src/pacemaker.h:35: first defined here
/usr/bin/ld: boothd-attr.o:./src/pacemaker.h:35: multiple definition of `pcmk_handler'; boothd-main.o:./src/pacemaker.h:35: first defined here