### PR TITLE
Fix gcc-10 warnings for packed struct members

### DIFF
--- a/src/booth.h
+++ b/src/booth.h
@@ -171,7 +171,7 @@ struct geo_attr {
 	/** Who set it (currently unused)
 	struct booth_site *origin;
 	*/
-} __attribute__((packed));
+};
 
 struct hmac {
 	/** hash id, currently set to constant BOOTH_HASH */
@@ -321,7 +321,7 @@ struct booth_site {
 	/** last timestamp seen from this site */
 	uint32_t last_secs;
 	uint32_t last_usecs;
-} __attribute__((packed));
+};
 
 
 


### PR DESCRIPTION
transport.c: In function ‘booth_tcp_open’:
transport.c:656:42: warning: taking address of packed member of ‘struct booth_site’ may result in an unaligned pointer value [-Waddress-of-packed-member]
  656 |  rv = connect_nonb(s, (struct sockaddr *)&to->sa6, to->saddrlen, 10);
      |                                          ^~~~~~~~
transport.c: In function ‘message_recv’:
transport.c:1108:7: warning: taking address of packed member of ‘struct booth_site’ may result in an unaligned pointer value [-Waddress-of-packed-member]
 1108 |  time(&source->last_recv);
      |       ^~~~~~~~~~~~~~~~~~
main.c: In function ‘format_peers’:
main.c:230:14: warning: taking address of packed member of ‘struct booth_site’ may result in an unaligned pointer value [-Waddress-of-packed-member]
  230 |    localtime(&s->last_recv));
      |              ^~~~~~~~~~~~~
attr.c: In function ‘store_geo_attr’:
attr.c:282:13: warning: taking address of packed member of ‘struct geo_attr’ may result in an unaligned pointer value [-Waddress-of-packed-member]
  282 |    get_time(&a->update_ts);
      |             ^~~~~~~~~~~~~
timer.h:43:48: note: in definition of macro ‘get_time’
   43 | #define get_time(p) clock_gettime(BOOTH_CLOCK, p)
      |                                                ^
attr.c: In function ‘append_attr’:
attr.c:337:18: warning: taking address of packed member of ‘struct geo_attr’ may result in an unaligned pointer value [-Waddress-of-packed-member]
  337 |  if (is_time_set(&a->update_ts)) {
      |                  ^~~~~~~~~~~~~
attr.c:338:16: warning: taking address of packed member of ‘struct geo_attr’ may result in an unaligned pointer value [-Waddress-of-packed-member]
  338 |   ts = wall_ts(&a->update_ts);
      |                ^~~~~~~~~~~~~