### PR TITLE
tests: Make test work for Debian systems

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -1,20 +1,14 @@
-import subprocess
-import re
-import sys
-
-def run_cmd(cmd):
-    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    (stdout, stderr) = p.communicate()
-    return (stdout, stderr, p.returncode)
+import socket
 
 def get_IP():
-    (stdout, stderr, returncode) = run_cmd(['hostname', '-i'])
-    if returncode != 0:
-        raise RuntimeError("Failed to run hostname -i:\n" + stderr)
-    # in case multiple IP addresses are returned, use only the first
-    # and also strip '%<device>' part possibly present with IPv6 address;
-    # in Python 3 context, only expect ASCII/UTF-8 encodings for the
-    # obtained input bytes
-    ret = re.sub(r'\s.*', '',
-                 stdout if sys.version_info[0] < 3 else str(stdout, 'UTF-8'))
-    return "::1" if '%' in ret else ret
+    # IPv4 only for now
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(('147.4.215.19', 9929))
+        ret = s.getsockname()[0]
+    except:
+        ret = '127.0.0.1'
+    finally:
+        s.close()
+
+    return ret


### PR DESCRIPTION
Debian is storing 127.0.1.1 address into /etc/hosts for local hostname.
Booth function find_myself is unable to find such address and fails.

Solution is based on using connect on udp socket and reading local
address.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>