### PR TITLE
build: Do not link with pcmk libraries

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,7 +23,7 @@ boothd_SOURCES		+= auth.c
 endif
 
 boothd_LDFLAGS		= $(OS_DYFLAGS) -L./
-boothd_LDADD		= -lm $(GLIB_LIBS) $(ZLIB_LIBS) $(PCMK_LIBS)
+boothd_LDADD		= -lm $(GLIB_LIBS) $(ZLIB_LIBS)
 boothd_CFLAGS		= $(GLIB_CFLAGS) $(PCMK_CFLAGS)
 
 if !LOGGING_LIBQB


### PR DESCRIPTION
Patch 4205de05fe337d1b1127fae302e6e6c2f0613ccf introduced better way to
check for pacemaker headers but also usage of PCMK_LIBS when linking
boothd.

This is not needed, because boothd uses just crm/services.h header file
for inclusion of OCF return codes, so patch removes the use of PCMK_LIBS.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>