### PR TITLE
tests: Allow parallel running of tests

### DIFF
--- a/README-testing
+++ b/README-testing
@@ -134,6 +134,11 @@ It is also possible to run the tests as a root when
 "--allow-root-user" parameter is used or if
 the BOOTH_RUNTESTS_ROOT_USER environment variable is defined.
 
+By default tests uses TCP port based on current PID in range
+from 9929 to 10937 to allow running multiple instances in parallel.
+It is possible to use "--single-instance" parameter or define
+BOOTH_RUNTESTS_SINGLE_INSTANCE environment variable to make tests use
+only single port (9929), but parallel instances will fail.
 
 
 

--- a/test/boothtestenv.py.in
+++ b/test/boothtestenv.py.in
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 
 from assertions  import BoothAssertions
+from utils       import use_single_instance
 
 class BoothTestEnvironment(unittest.TestCase, BoothAssertions):
     abs_test_src_path    = os.path.abspath('TEST_SRC_DIR')
@@ -23,7 +24,10 @@ class BoothTestEnvironment(unittest.TestCase, BoothAssertions):
         if os.geteuid() == 0:
             os.chmod(self.test_path, 0o777)
 
-        self.ensure_boothd_not_running()
+        # It's not good idea to kill other instancies so call following function
+        # only if single_instance mode is used
+        if use_single_instance():
+            self.ensure_boothd_not_running()
 
     def ensure_boothd_not_running(self):
         # Need to redirect STDERR in case we're not root, in which

--- a/test/runtests.py.in
+++ b/test/runtests.py.in
@@ -14,6 +14,8 @@ from clienttests import ClientConfigTests
 from sitetests   import SiteConfigTests
 #from arbtests    import ArbitratorConfigTests
 
+from utils       import use_single_instance
+
 if __name__ == '__main__':
     # Likely assumption for the root exclusion is the amount of risk
     # associated with what naturally accompanies root privileges:
@@ -64,7 +66,7 @@ if __name__ == '__main__':
         runner_args['failfast'] = True
         pass
 
-    if os.geteuid() != 0:
+    if os.geteuid() != 0 and use_single_instance():
         # not root, so safe
         # needed because old instances might still use the UDP port.
         os.system("killall boothd")

--- a/test/serverenv.py
+++ b/test/serverenv.py
@@ -4,7 +4,7 @@ import time
 
 from boothrunner  import BoothRunner
 from boothtestenv import BoothTestEnvironment
-from utils        import get_IP
+from utils        import get_IP, use_single_instance
 
 class ServerTestEnvironment(BoothTestEnvironment):
     '''
@@ -26,6 +26,11 @@ ticket="ticketB"
 """
     site_re = re.compile('^site=".+"', re.MULTILINE)
     working_config = re.sub(site_re, 'site="%s"' % get_IP(), typical_config, 1)
+
+    if not use_single_instance():
+        # use port based on pid
+        port_re = re.compile('^port=".+"', re.MULTILINE)
+        working_config = re.sub(port_re, 'port="%s"' % (9929 + (os.getpid() % 1009)), working_config, 1)
 
     def run_booth(self, expected_exitcode, expected_daemon,
                   config_text=None, config_file=None, lock_file=True,

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,4 +1,6 @@
 import socket
+import os
+import sys
 
 def get_IP():
     # IPv4 only for now
@@ -12,3 +14,6 @@ def get_IP():
         s.close()
 
     return ret
+
+def use_single_instance():
+    return ("--single-instance" in sys.argv) or (os.environ.get("BOOTH_RUNTESTS_SINGLE_INSTANCE") != None)


### PR DESCRIPTION
To allow running multiple instances of tests in parallel only few
changes were needed:
- Do not killall boothd on start
- Do not call ensure_boothd_not_running and rely on cleanup mechanism of
tests itself (works quite well). Another advantage is not rely on
(deprecated) netstat and perl one-liner.
- Generate "unique" port for each of the instance (based on PID)

This patch is (mostly) to allow building rpm (check section) on both i686
and x86_64 when only one physical machine is used (example reproducer is
Fedora Koji) for both architectures.

I was also thinking about having unique port for each test case where
working_config is needed, but such solution was more collisions prone
(and more invasive) than one port per tests instance.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>