### PR TITLE
Fix problems found by coverity

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -843,7 +843,7 @@ static int _lockfile(int mode, int *fdp, pid_t *locked_by)
 	 * Try to create it, but ignore errors. */
 	if (strncmp(cl.lockfile, BOOTH_RUN_DIR,
 				strlen(BOOTH_RUN_DIR)) == 0)
-		mkdir(BOOTH_RUN_DIR, 0775);
+		(void)mkdir(BOOTH_RUN_DIR, 0775);
 
 
 	if (locked_by)

--- a/src/pacemaker.c
+++ b/src/pacemaker.c
@@ -365,7 +365,7 @@ static int pcmk_get_attr(struct ticket_config *tk, const char *attr, const char 
 		rv = errno;
 		log_error("popen error %d (%s) for \"%s\"",
 				rv, strerror(rv), cmd);
-		return rv || EINVAL;
+		return (rv != 0 ? rv : EINVAL);
 	}
 	if (fgets(line, BOOTH_ATTRVAL_LEN, p) == NULL) {
 		rv = ENODATA;
@@ -499,7 +499,7 @@ static int pcmk_load_ticket(struct ticket_config *tk)
 		pipe_rv = errno;
 		log_error("popen error %d (%s) for \"%s\"",
 				pipe_rv, strerror(pipe_rv), cmd);
-		return pipe_rv || -EINVAL;
+		return (pipe_rv != 0 ? pipe_rv : EINVAL);
 	}
 
 	rv = parse_ticket_state(tk, p);

--- a/src/transport.c
+++ b/src/transport.c
@@ -169,7 +169,7 @@ int _find_myself(int family, struct booth_site **mep, int fuzzy_allowed)
 		return 0;
 	}
 
-	setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf));
+	(void)setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf));
 
 	memset(&nladdr, 0, sizeof(nladdr));
 	nladdr.nl_family = AF_NETLINK;
@@ -514,7 +514,7 @@ static void process_tcp_listener(int ci)
 			  fd, errno);
 		return;
 	}
-	setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char *)&one, sizeof(one));
+	(void)setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char *)&one, sizeof(one));
 
 	flags = fcntl(fd, F_GETFL, 0);
 	fcntl(fd, F_SETFL, flags | O_NONBLOCK);


### PR DESCRIPTION
None of the problem is critical (booth is really in nice shape in this respect), but I think it make sense to have them fixed. Result of this PR is https://ci.kronosnet.org/job/booth-build-covscan/booth-build-covscan=coverity/16/consoleText. There are 3 warnings left, but it is really just coverity totally ignoring the call of `check_max_len_valid`