### PR TITLE
booth.spec: Change naming scheme for upgrades

### DIFF
--- a/booth.spec.in
+++ b/booth.spec.in
@@ -50,6 +50,8 @@
 %define pkg_group Productivity/Clustering/HA
 %endif
 
+%global release 1
+
 Name:           booth
 Url:            https://github.com/ClusterLabs/booth
 Summary:        Ticket Manager for Multi-site Clusters
@@ -60,7 +62,7 @@ License:        GPLv2+
 %endif
 Group:          %{pkg_group}
 Version:        @version@
-Release:        1%{?numcomm:.%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}%{?dist}
+Release:        %{?numcomm:%{numcomm}.}%{release}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}%{?alphatag:.git}%{?dist}
 Source:         https://github.com/ClusterLabs/booth/archive/v%{version}%{?gittarver}/%{name}-%{version}%{?gitver}.tar.gz
 Source1:        %name-rpmlintrc
 BuildRequires:  @asciidoc@


### PR DESCRIPTION
Previously the release was set to 1.$numcomm.$sha1.$dirty.$dist.
This is suboptimal for downstream, because when release increases then
downstream version is always newer no matter what numcomm is. So when CI
tries to install upstream version it won't get installed.

Proposed solution is to use $numcomm.$release.$sha1.$dirty.git.$dist so
numcomm is now second most important (version is first one) making any
pushed version bigger than any downstream version.

This scheme also works with rpmdev-bumpspec because release is now
global variable (rpmdev-bumpspec will increase "%global release" rather
than the release field).

Signed-off-by: Jan Friesse <jfriesse@redhat.com>