### PR TITLE
[build] ship booth.pc with basic booth build information for downstre…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ test/boothtestenv.py
 test/runtests.py
 
 booth.spec
+booth.pc
 
 # cscope files
 cscope.*

--- a/Makefile.am
+++ b/Makefile.am
@@ -77,6 +77,9 @@ nodist_boothnoarch_SCRIPTS = script/service-runnable
 
 sbin_SCRIPTS		= script/booth-keygen
 
+pkgconfigdir		= $(datadir)/pkgconfig
+pkgconfig_DATA		= booth.pc
+
 TESTS			= test/runtests.py
 
 SUBDIRS			= src docs conf

--- a/booth.pc.in
+++ b/booth.pc.in
@@ -1,0 +1,7 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+confdir=@BOOTHSYSCONFDIR@
+
+Name: @PACKAGE@
+Version: @VERSION@
+Description: @PACKAGE@ build information required for downstream projects

--- a/booth.spec.in
+++ b/booth.spec.in
@@ -240,6 +240,9 @@ echo "%%with_run_build_tests set to %with_run_build_tests; skipping tests"
 %dir %{_datadir}/booth
 %{_datadir}/booth/service-runnable
 
+%dir %{_datadir}/pkgconfig
+%{_datadir}/pkgconfig/booth.pc
+
 %doc AUTHORS README COPYING
 %doc README.upgrade-from-v0.1
 

--- a/configure.ac
+++ b/configure.ac
@@ -165,6 +165,7 @@ AC_CHECK_FUNCS([alarm alphasort atexit bzero dup2 endgrent endpwent fcntl \
 		sched_get_priority_max sched_setscheduler])
 
 AC_CONFIG_FILES([Makefile
+		 booth.pc
 		 src/Makefile
 		 docs/Makefile
 		 conf/Makefile])


### PR DESCRIPTION
…am packages to use

some packages, such as pcs, needs to have specific information about booth
installation paths in order to configure booth properly.

in a similar fashion as systemd (shipping systemd.pc), add similar feature to booth.

In general this change does NOT affect any downstream distributions as they all
use pretty much standard paths, but it makes it a ton easier to build / install
and test booth in CI where all package are installed in non-standard paths.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>