### PR TITLE
Don't lock all current and future memory if can't increase memlock rl…

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1257,11 +1257,15 @@ static void set_scheduler(void)
 
 	rlimit.rlim_cur = RLIM_INFINITY;
 	rlimit.rlim_max = RLIM_INFINITY;
-	setrlimit(RLIMIT_MEMLOCK, &rlimit);
-	rv = mlockall(MCL_CURRENT | MCL_FUTURE);
+	rv = setrlimit(RLIMIT_MEMLOCK, &rlimit);
 	if (rv < 0) {
-		log_error("mlockall failed");
-	}
+		log_error("setrlimit failed");
+	} else {
+                rv = mlockall(MCL_CURRENT | MCL_FUTURE);
+                if (rv < 0) {
+                        log_error("mlockall failed");
+                }
+        }
 
 	rv = sched_get_priority_max(SCHED_RR);
 	if (rv != -1) {


### PR DESCRIPTION
…imit

If we fail to increase our RLIMIT_MEMLOCK, then locking all our current
and future memory is extremely dangerous; once our memory use reaches
our RLIMIT_MEMLOCK, memory allocations will start failing, very likely
leading to our entire process crashing.

This can happen if we aren't a privileged process, for example if
running as non-root user, or inside an unprivileged container.