### PR TITLE
config: Remove deprecated net functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,7 +153,7 @@ AC_FUNC_SELECT_ARGTYPES
 AC_TYPE_SIGNAL
 AC_FUNC_VPRINTF
 AC_CHECK_FUNCS([alarm alphasort atexit bzero dup2 endgrent endpwent fcntl \
-		getcwd getpeerucred getpeereid gettimeofday inet_ntoa memmove \
+		getcwd getpeerucred getpeereid gettimeofday memmove \
 		memset mkdir scandir select socket strcasecmp strchr strdup \
 		strerror strrchr strspn strstr \
 		sched_get_priority_max sched_setscheduler])


### PR DESCRIPTION
gethostbyname and inet_ntoa are deprecated and shouldn't be used. Also
gethostbyname is unable to handle ipv6.

Replace gethostbyname by getaddrinfo.

inet_ntoa is replaced by inet_ntop.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>