### PR TITLE
test: Enhance wait_for_lock_file

### DIFF
--- a/test/serverenv.py
+++ b/test/serverenv.py
@@ -133,8 +133,14 @@ ticket="ticketB"
         start = time.time()
         wait = 0.1
         while True:
-            if must_exist and os.path.exists(lock_file) and os.path.getsize(lock_file) > 0:
-                return True
+            if must_exist and os.path.exists(lock_file):
+                # Lock file must contain single line
+                l = open(lock_file)
+                lines = l.readlines()
+                l.close()
+
+                if len(lines) == 1:
+                    return True
             if not must_exist and not os.path.exists(lock_file):
                 return True
             elapsed = time.time() - start


### PR DESCRIPTION
Test of file existence and size > 0 seems to be not reliable enough so
mimic behavior of get_daemon_pid_from_lock_file.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>

(hopefully solves CI failures)