### PR TITLE
Revert "Refactor: main: substitute is_auth_req macro"

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -364,7 +364,7 @@ static int setup_config(int type)
 	if (rv < 0)
 		goto out;
 
-	if (is_auth_req()) {
+	if (booth_conf->authfile[0] != '\0') {
 		rv = read_authkey();
 		if (rv < 0)
 			goto out;


### PR DESCRIPTION
This reverts commit da79b8ba28ad4837a0fee13e5f8fb6f89fe0e24c.

authfile != authkey

Signed-off-by: Jan Friesse <jfriesse@redhat.com>

Solves #114