### PR TITLE
rpm: use new package name for pacemaker devel on opensuse

### DIFF
--- a/booth.spec.in
+++ b/booth.spec.in
@@ -80,7 +80,11 @@ BuildRequires:  libgcrypt-devel
 %if 0%{?fedora} || 0%{?centos} || 0%{?rhel}
 BuildRequires:  pacemaker-libs-devel
 %else
+%if 0%{?suse_version} > 1500
+BuildRequires:  libpacemaker3-devel
+%else
 BuildRequires:  libpacemaker-devel
+%endif
 %endif
 %if 0%{?with_glue}
 %if 0%{?fedora} || 0%{?centos} || 0%{?rhel}


### PR DESCRIPTION
Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>