### PR TITLE
ticket: Fix compiler warning

### DIFF
--- a/src/ticket.c
+++ b/src/ticket.c
@@ -395,7 +395,8 @@ int list_ticket(char **pdata, unsigned int *len)
 	char timeout_str[64];
 	char pending_str[64];
 	char *data, *cp;
-	int i, alloc, site_index;
+	int i, site_index;
+	size_t alloc;
 	time_t ts;
 	int multiple_grant_warning_length = 0;
 


### PR DESCRIPTION
malloc expects size_t typed variable so change `alloc` to size_t.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>