### PR TITLE
unit file: Remove Alias directive

### DIFF
--- a/conf/booth@.service.in
+++ b/conf/booth@.service.in
@@ -8,7 +8,6 @@ ConditionFileNotEmpty=/etc/booth/%i.conf
 Conflicts=pacemaker.service
 
 [Install]
-Alias=boothd
 WantedBy=multi-user.target
 
 [Service]


### PR DESCRIPTION
Recent change in systemd made imposible to enable booth@.service any longer - more details in BZ
https://bugzilla.redhat.com/show_bug.cgi?id=2128998. Solution is to delete Alias directive.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>