### PR TITLE
Enhance config file error msg

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -541,6 +541,7 @@ extern int poll_timeout;
 int read_config(const char *path, int type)
 {
 	char line[1024];
+	char error_str_buf[1024];
 	FILE *fp;
 	char *s, *key, *val, *end_of_key;
 	const char *error;
@@ -788,7 +789,9 @@ no_value:
 		 * we don't know to which ticket the key refers
 		 */
 		if (!current_tk) {
-			error = "Unexpected keyword";
+			(void)snprintf(error_str_buf, sizeof(error_str_buf),
+			    "Unexpected keyword \"%s\"", key);
+			error = error_str_buf;
 			goto err;
 		}
 
@@ -868,7 +871,9 @@ no_value:
 			continue;
 		}
 
-		error = "Unknown keyword";
+		(void)snprintf(error_str_buf, sizeof(error_str_buf),
+		    "Unknown keyword \"%s\"", key);
+		error = error_str_buf;
 		goto err;
 	}
 	fclose(fp);

--- a/src/config.c
+++ b/src/config.c
@@ -699,7 +699,9 @@ no_value:
 			else if (strcasecmp(val, "SCTP") == 0)
 				booth_conf->proto = SCTP;
 			else {
-				error = "invalid transport protocol";
+				(void)snprintf(error_str_buf, sizeof(error_str_buf),
+				    "invalid transport protocol \"%s\"", val);
+				error = error_str_buf;
 				goto err;
 			}
 			got_transport = 1;

--- a/test/servertests.py
+++ b/test/servertests.py
@@ -110,7 +110,7 @@ class ServerTests(ServerTestEnvironment):
         config = re.sub('transport=.+', 'transport=SNEAKERNET', self.typical_config)
         (pid, ret, stdout, stderr, runner) = \
             self.run_booth(config_text=config, expected_exitcode=1, expected_daemon=False)
-        self.assertRegexpMatches(stderr, 'invalid transport protocol')
+        self.assertRegexpMatches(stderr, 'invalid transport protocol "SNEAKERNET"')
 
     def test_missing_final_newline(self):
         config = re.sub('\n$', '', self.working_config)
@@ -147,3 +147,17 @@ class ServerTests(ServerTestEnvironment):
         config = re.sub('#(.+147.+)', lambda m: m.group(1), self.working_config)
         self.run_booth(config_text=config,
                        expected_exitcode=None, expected_daemon=False)
+
+    def test_unknown_keyword(self):
+        # Test unexpected keyword before tickets definition
+        keyword='unknown-keyword'
+        config = re.sub('transport=', keyword + '=', self.typical_config)
+        (pid, ret, stdout, stderr, runner) = \
+            self.run_booth(config_text=config, expected_exitcode=1, expected_daemon=False)
+        self.assertRegexpMatches(stderr, 'Unexpected keyword "' + keyword + '"')
+
+        # Test unexpected keyword in tickets definition
+        config = re.sub('\n$', '\n' + keyword + '=value', self.typical_config)
+        (pid, ret, stdout, stderr, runner) = \
+            self.run_booth(config_text=config, expected_exitcode=1, expected_daemon=False)
+        self.assertRegexpMatches(stderr, 'Unknown keyword "' + keyword + '"')


### PR DESCRIPTION
Main idea is to improve error message during parsing a bit by adding keyword into "Unexpected/unknown keyword" error message. So instead of:
```
error: Unexpected keyword in config file line 9
```

it shows

```
Unexpected keyword "some-unknown-keyword" in config file line 9
```

Similar is done for transport value so instead of:
```
invalid transport protocol in config file line 8
```

it shows
```
invalid transport protocol "UDP2" in config file line 8
```

Last patch adds test for this functionality.