### PR TITLE
Improve asciidoc man pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ booth-*.tar*
 
 conf/booth*.service
 docs/*.8
+docs/*.8.html
 script/service-runnable
 script/unit-test.py
 src/b_config.h.in

--- a/docs/booth-keygen.8.txt
+++ b/docs/booth-keygen.8.txt
@@ -22,7 +22,7 @@ using '/dev/urandom' as source.
 PARAMETERS
 ----------
 
-*'auth-file'*::
+'auth-file'::
 	The file to contain the generated key. Defaults to
 	'/etc/booth/authkey'. Use absolute paths.
 

--- a/docs/boothd.8.txt
+++ b/docs/boothd.8.txt
@@ -163,22 +163,22 @@ counters for the sent packets and the second one for the received
 packets. The first counter is the total number of packets and
 descriptions of the other counters follows:
 
-'resends'::
+'resends';;
 	Packets which had to be resent because the recipient didn't
 	acknowledge a message. This usually means that either the
 	message or the acknowledgement got lost. The number of
 	resends usually reflect the network reliability.
 
-'error'::
+'error';;
 	Packets which either couldn't be sent, got truncated, or were
 	badly formed. Should be zero.
 
-'invalid'::
+'invalid';;
 	These packets contain either invalid or non-existing ticket
 	name or refer to a non-existing ticket leader. Should be
 	zero.
 
-'authfail'::
+'authfail';;
 	Packets which couldn't be authenticated. Should be zero.
 
 CONFIGURATION FILE

--- a/docs/boothd.8.txt
+++ b/docs/boothd.8.txt
@@ -119,13 +119,13 @@ Whether the binary is called as 'boothd' or 'booth' doesn't matter; the first
 argument determines the mode of operation.
 
 
-*'daemon'*::
+'daemon'::
 	Tells 'boothd' to serve a site. The locally configured interfaces are
 	searched for an IP address that is defined in the configuration.
 	booth then runs in either /arbitrator/ or /site/ mode.
 
 
-*'client'*::
+'client'::
 	Booth clients can list the ticket information (see also 'crm_ticket -L'),
 	and revoke or grant tickets to a site.
 +
@@ -147,13 +147,13 @@ interfaces, it knows which site it belongs to.
 Use '-s' to direct client to connect to a different site.
 
 
-*'status'*::
+'status'::
 	'boothd' looks for the (locked) PID file and the UDP socket, prints
 	some output to stdout (for use in shell scripts) and returns
 	an OCF-compatible return code.
 	With '-D', a human-readable message is printed to STDERR as well.
 
-*'peers'*::
+'peers'::
 	List the other 'boothd' servers we know about.
 +
 In addition to the type, name (IP address), and the last time the
@@ -202,17 +202,17 @@ and end of the line, and around the ''='', are ignored.
 
 The following key/value pairs are defined:
 
-*'port'*::
+'port'::
 	The UDP/TCP port to use. Default is '9929'.
 
-*'transport'*::
+'transport'::
 	The transport protocol to use for Raft exchanges.
 	Currently only UDP is supported.
 +
 Clients use TCP to communicate with a daemon; Booth 
 will always bind and listen to both UDP and TCP ports.
 
-*'authfile'*::
+'authfile'::
 	File containing the authentication key. The key can be either
 	binary or text. If the latter, then both leading and trailing
 	white space, including new lines, is ignored. This key is a
@@ -220,7 +220,7 @@ will always bind and listen to both UDP and TCP ports.
 	servers. The key must be between 8 and 64 characters long and
 	be readable only by the file owner.
 
-*'maxtimeskew'*::
+'maxtimeskew'::
 	As protection against replay attacks, packets contain
 	generation timestamps. Such a timestamp is not allowed to be
 	too old. Just how old can be specified with this parameter.
@@ -230,16 +230,16 @@ will always bind and listen to both UDP and TCP ports.
 	parameter to a higher value. The time skew test is performed
 	only in concert with authentication.
 
-*'debug'*::
+'debug'::
 	Specifies the debug output level. Alternative to
 	command line argument. Effective only for 'daemon'
 	mode of operation.
 
-*'site'*::
+'site'::
 	Defines a site Raft member with the given IP. Sites can
 	acquire tickets. The sites' IP should be managed by the cluster.
 
-*'arbitrator'*::
+'arbitrator'::
 	Defines an arbitrator Raft member with the given IP.
 	Arbitrators help reach consensus in elections and cannot hold
 	tickets.
@@ -247,14 +247,14 @@ will always bind and listen to both UDP and TCP ports.
 Booth needs at least three members for normal operation. Odd
 number of members provides more redundancy.
 
-*'site-user'*, *'site-group'*, *'arbitrator-user'*, *'arbitrator-group'*::
+'site-user', 'site-group', 'arbitrator-user', 'arbitrator-group'::
 	These define the credentials 'boothd' will be running with.
 +
 On a (Pacemaker) site the booth process will have to call 'crm_ticket', so the 
 default is to use 'hacluster':'haclient'; for an arbitrator this user and group 
 might not exists, so there we default to 'nobody':'nobody'.
 
-*'ticket'*::
+'ticket'::
 	Registers a ticket. Multiple tickets can be handled by single
 	Booth instance.
 +
@@ -264,14 +264,14 @@ ticket specifications.
 
 All times are in seconds.
 
-*'expire'*::
+'expire'::
 	The lease time for a ticket. After that time the ticket can be 
 	acquired by another site if the ticket holder is not
 	reachable.
 +
 The default is '600'.
 
-*'acquire-after'*::
+'acquire-after'::
 	Once a ticket is lost, wait this time in addition before
 	acquiring the ticket.
 +
@@ -283,7 +283,7 @@ the protected resources and the fencing configuration.
 +
 The default is '0'.
 
-*'renewal-freq'*::
+'renewal-freq'::
 	Set the ticket renewal frequency period.
 +
 If the network reliability is often reduced over prolonged
@@ -294,14 +294,14 @@ specified in 'before-acquire-handler' is run. In that case the
 'renewal-freq' parameter is effectively also the local cluster
 monitoring interval.
 
-*'timeout'*::
+'timeout'::
 	After that time 'booth' will re-send packets if there was an
 	insufficient number of replies. This should be long enough to
 	allow packets to reach other members.
 +
 The default is '5'.
 
-*'retries'*::
+'retries'::
 	Defines how many times to retry sending packets before giving
 	up waiting for acks from other members.
 +
@@ -309,18 +309,18 @@ Default is '10'. Values lower than 3 are illegal.
 +
 Ticket renewals should allow for this number of retries. Hence,
 the total retry time must be shorter than the renewal time
-(either half the expire time or *'renewal-freq'*):
+(either half the expire time or 'renewal-freq'):
 
 	timeout*(retries+1) < renewal
 
-*'weights'*::
+'weights'::
 	A comma-separated list of integers that define the weight of individual 
 	Raft members, in the same order as the 'site' and 'arbitrator' lines.
 +
 Default is '0' for all; this means that the order in the configuration 
 file defines priority for conflicting requests.
 
-*'before-acquire-handler'*::
+'before-acquire-handler'::
 	If set, this parameter specifies either a file containing a
 	program to be run or a directory where a number of programs
 	can reside. They are invoked before 'boothd' tries to acquire
@@ -342,7 +342,7 @@ See below for details about booth specific environment variables.
 The distributed 'service-runnable' script is an example which may
 be used to test whether a pacemaker resource can be started.
 
-*'attr-prereq'*::
+'attr-prereq'::
 	Sites can have GEO attributes managed with the 'geostore(8)'
 	program. Attributes are within ticket's scope and may be
 	tested by 'boothd' for additional control of ticket failover
@@ -374,7 +374,7 @@ human.
 Note that there can be no guarantee on whether an attribute value
 is up to date, i.e. if it actually reflects the current state.
 
-*'mode'*::
+'mode'::
 	Specifies if the ticket is manual or automatic.
 +
 By default all tickets are automatic (that is, they are fully
@@ -470,19 +470,19 @@ Currently, there's only one external handler defined (see the
 
 The following environment variables are exported to the handler:
 
-*'BOOTH_TICKET'::
+'BOOTH_TICKET'::
 	The ticket name, as given in the configuration file. (See 'ticket' item above.)
 
-*'BOOTH_LOCAL'::
+'BOOTH_LOCAL'::
 	The local site name, as defined in 'site'.
 
-*'BOOTH_CONF_PATH'::
+'BOOTH_CONF_PATH'::
 	The path to the active configuration file.
 
-*'BOOTH_CONF_NAME'::
+'BOOTH_CONF_NAME'::
 	The configuration name, as used by the '-c' commandline argument.
 
-*'BOOTH_TICKET_EXPIRES'::
+'BOOTH_TICKET_EXPIRES'::
 	When the ticket expires (in seconds since 1.1.1970), or '0'.
 
 The handler is invoked with positional arguments specified after
@@ -491,14 +491,14 @@ it.
 FILES
 -----
 
-*'/etc/booth/booth.conf'*::
+'/etc/booth/booth.conf'::
 	The default configuration file name. See also the '-c' argument.
 
-*'/etc/booth/authkey'*::
+'/etc/booth/authkey'::
 	There is no default, but this is a typical location for the
 	shared secret (authentication key).
 
-*'/var/run/booth/'*::
+'/var/run/booth/'::
 	Directory that holds PID/lock files. See also the 'status' command.
 
 

--- a/docs/boothd.8.txt
+++ b/docs/boothd.8.txt
@@ -230,6 +230,11 @@ will always bind and listen to both UDP and TCP ports.
 	parameter to a higher value. The time skew test is performed
 	only in concert with authentication.
 
+*'debug'*::
+	Specifies the debug output level. Alternative to
+	command line argument. Effective only for 'daemon'
+	mode of operation.
+
 *'site'*::
 	Defines a site Raft member with the given IP. Sites can
 	acquire tickets. The sites' IP should be managed by the cluster.
@@ -375,11 +380,6 @@ is up to date, i.e. if it actually reflects the current state.
 By default all tickets are automatic (that is, they are fully
 controlled by Raft algorithm). Assign the strings "manual" or
 "MANUAL" to define the ticket as manually controlled.
-
-*'debug'*::
-	Specifies the debug output level. Alternative to
-	command line argument. Effective only for 'daemon'
-	mode of operation.
 
 One example of a booth configuration file:
 

--- a/docs/boothd.8.txt
+++ b/docs/boothd.8.txt
@@ -258,8 +258,8 @@ might not exists, so there we default to 'nobody':'nobody'.
 	Registers a ticket. Multiple tickets can be handled by single
 	Booth instance.
 +
-Use the special ticket name '__defaults__' to modify the
-defaults. The '__defaults__' stanza must precede all the other
+Use the special ticket name `__defaults__` to modify the
+defaults. The `__defaults__` stanza must precede all the other
 ticket specifications.
 
 All times are in seconds.

--- a/docs/boothd.8.txt
+++ b/docs/boothd.8.txt
@@ -66,9 +66,9 @@ The configuration name also determines the name of the PID file - for the defaul
 *-s*::
 	Site address or name.
 +
-	The special value 'other' can be used to specify the other
-	site. Obviously, in that case, the booth configuration must
-	have exactly two sites defined.
+The special value 'other' can be used to specify the other
+site. Obviously, in that case, the booth configuration must
+have exactly two sites defined.
 
 *-F*::
 	'immediate grant': Don't wait for unreachable sites to
@@ -78,10 +78,10 @@ The configuration name also determines the name of the PID file - for the defaul
 	which is currently granted. See the 'Manual tickets' section
 	below for more details.
 +
-	This option may be DANGEROUS. It makes booth grant the ticket
-	even though it cannot ascertain that unreachable sites don't
-	hold the same ticket. It is up to the user to make sure that
-	unreachable sites don't have this ticket as granted.
+This option may be DANGEROUS. It makes booth grant the ticket
+even though it cannot ascertain that unreachable sites don't
+hold the same ticket. It is up to the user to make sure that
+unreachable sites don't have this ticket as granted.
 
 *-w*::
 	'wait for the request outcome': The client waits for the

--- a/docs/geostore.8.txt
+++ b/docs/geostore.8.txt
@@ -82,22 +82,22 @@ Per default 'booth' is used, which results in the path
 COMMANDS
 --------
 
-*'set'*::
+'set'::
 	Sets the attribute to the value.
 
 
-*'get'*::
+'get'::
 	Get the attribute value and print it to 'stdout'. If the
 	attribute doesn't exist, appropriate error message is printed
 	to 'stderr'.
 
 
-*'delete'*::
+'delete'::
 	Delete the attribute. If the attribute doesn't exist,
 	appropriate error message is printed to 'stderr'.
 
 
-*'list'*::
+'list'::
 	List all attributes and their values stored at the site.
 
 


### PR DESCRIPTION
Series of patches to improve look of how generated man pages (and html files).

Pre/post files can be viewed at https://honzaf.fedorapeople.org/booth-man-asciidoc/asciidoc-pre/ (without patches generated by asciidoc), https://honzaf.fedorapeople.org/booth-man-asciidoc/asciidoc-post/ (with patches generated by asciidoc), https://honzaf.fedorapeople.org/booth-man-asciidoc/asciidoctor-pre/ (without patches generated by asciidoctor), https://honzaf.fedorapeople.org/booth-man-asciidoc/asciidoctor-post/ (with patches generated by asciidoctor). It was really tempting to screenshot console with man page ;) but I've rather decided to use groff and convert man page to html (`for i in *.8;do groff  -mandoc -Thtml "$i" > "$i-groff.html";done`).

Patches have (I hope) quite good description but some highlights of patches:
1. second patch (`man: Indent peers counters`) - nicely visible everywhere (so for example https://honzaf.fedorapeople.org/booth-man-asciidoc/asciidoctor-pre/boothd.8-groff.html#COMMANDS vs https://honzaf.fedorapeople.org/booth-man-asciidoc/asciidoctor-post/boothd.8-groff.html#COMMANDS) - this was really confusing (there is actually BZ about this problem) because of no indentation of resends/error/... so visually this looks like command - indentation should remove this problem.
2. third patch (`man: Do not format __defaults__`) is self-describing and if nothing else gets merged this one should be - `Use the special ticket name defaults to modify` is simply misleading and correct one is really `Use the special ticket name __defaults__ to modify`
3. forth patch (`man: Remove italic bold formatting`) is only visible when formatting man page (https://honzaf.fedorapeople.org/booth-man-asciidoc/asciidoctor-pre/boothd.8-groff.html#COMMANDS vs https://honzaf.fedorapeople.org/booth-man-asciidoc/asciidoctor-post/boothd.8-groff.html#COMMANDS) - notice how after `daemon` everything is italic till `CONFIGURATION FILE ` (console version looks much worse)
4. fifth patch (`man: remove literal paragraph format from boothd.8`) is really best visible in asciidoc html output and (probably) not in console so https://honzaf.fedorapeople.org/booth-man-asciidoc/asciidoc-pre/boothd.8.html vs https://honzaf.fedorapeople.org/booth-man-asciidoc/asciidoc-post/boothd.8.html) - notice `The special value 'other' can be used to specify the other site. Obviously, in that case, the booth configuration must have exactly two sites defined.` section.

I'm really not super happy with forth patch because bold+italic is nicer in html output but I was unable to find a way how to make asciidoctor work for man page output (it's questionable how much is this problem of asciidoctor vs troff itself).