### PR TITLE
spec: Migrate to SPDX license

### DIFF
--- a/booth.spec.in
+++ b/booth.spec.in
@@ -55,11 +55,7 @@
 Name:           booth
 Url:            https://github.com/ClusterLabs/booth
 Summary:        Ticket Manager for Multi-site Clusters
-%if 0%{?suse_version}
-License:        GPL-2.0+
-%else
-License:        GPLv2+
-%endif
+License:        GPL-2.0-or-later
 Group:          %{pkg_group}
 Version:        @version@
 Release:        %{?numcomm:%{numcomm}.}%{release}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}%{?alphatag:.git}%{?dist}


### PR DESCRIPTION
Both Fedora and openSUSE now recommends to use SPDX shortname format for License.