### PR TITLE
main: Fix exit code on grant/revoke command error

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -762,7 +762,7 @@ static int do_command(cmd_request_t cmd)
 	else if (cmd == CMD_REVOKE)
 		op_str = "revoke";
 
-	rv = 0;
+	rv = -1;
 	site = NULL;
 
 	/* Always use TCP for client - at least for now. */


### PR DESCRIPTION
Client command grant/revoke was returning success exit code on some failures (site not configured, arbitrator, no tickets given). Test case is running
`booth grant -s $IP; echo $?`, where IP is not configured in the config file.

Patch fixes this behavior so error code is returned.