### PR TITLE
attr: Fix memory leak for list and get operation

### DIFF
--- a/src/attr.c
+++ b/src/attr.c
@@ -372,7 +372,7 @@ static cmd_result_t attr_get(struct ticket_config *tk, int fd, struct boothc_att
 	if (send_header_plus(fd, &hdr, attr_val->str, attr_val->len))
 		rv = RLT_SYNC_FAIL;
 	if (attr_val)
-		g_string_free(attr_val, FALSE);
+		g_string_free(attr_val, TRUE);
 	return rv;
 }
 
@@ -398,7 +398,7 @@ static cmd_result_t attr_list(struct ticket_config *tk, int fd, struct boothc_at
 	rv = send_header_plus(fd, &hdr, data->str, data->len);
 
 	if (data)
-		g_string_free(data, FALSE);
+		g_string_free(data, TRUE);
 	return rv;
 }
 


### PR DESCRIPTION
attr_get and attr_list were allocation GString but they were calling g_string_free with second argument set to FALSE, what means GLib was returning character data to caller (see g_string_free for complete documentation) instead of freeing them. This return value was ignored by attr_* functions so memory leaked.

Patch to fix this problem is simple - just set second argument of g_string_free to TRUE so GLib takes care of freeing all data.

(found by newest gcc in Fedora rawhide which displays warning)
