### PR TITLE
tests: Fix Python 3.12 warning

### DIFF
--- a/test/boothtestenv.py.in
+++ b/test/boothtestenv.py.in
@@ -36,7 +36,7 @@ class BoothTestEnvironment(unittest.TestCase, BoothAssertions):
         # pid for those and only those, which is exactly what we want
         # here.
         subprocess.call("(netstat -tlnp || ss -tlnp) 2>&1 | " +
-            "perl -lne '(m,LISTEN\s+(\d+)/boothd, || /\"boothd\".*pid=(\d+)/) and kill 15, $1'",
+            "perl -lne '(m,LISTEN\\s+(\\d+)/boothd, || /\"boothd\".*pid=(\\d+)/) and kill 15, $1'",
             shell=True)
 
     def get_tempfile(self, identity):


### PR DESCRIPTION
Python 3.12 warns about invalid escape sequence '\s'. It is still correctly converted, but I guess it is better to escape '\' character properly to avoid future breakage.