### PR TITLE
build: Make distcheck work for non-root user

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -54,6 +54,9 @@ MAINTAINERCLEANFILES	= Makefile.in aclocal.m4 configure depcomp \
 			  autoheader automake autoconf test_lense.sh \
 			  compile
 
+# Don't try to install files outside build directory for "make distcheck".
+AM_DISTCHECK_CONFIGURE_FLAGS = --with-ocfdir="$$dc_install_base/lib/ocf"
+
 dist_doc_DATA		= AUTHORS README COPYING README.upgrade-from-v0.1 README-testing
 
 boothconfdir		= ${BOOTHSYSCONFDIR}


### PR DESCRIPTION
make distcheck calls configure script with --prefix to allow installation to tmp directory. ocfdir is not using ${prefix} and instead contains absolute path (either taken from resource-agents.pc or hardcoded one) so make install fails when running as non-root user.

Solution is taken from pacemaker project and it relies on setting AM_DISTCHECK_CONFIGURE_FLAGS so --with-ocfdir is added with directory where user has write permissions.

Big thanks to Fabio M. Di Nitto <fdinitto@redhat.com> for finding this solution.