### PR TITLE
Gcrypt fix

### DIFF
--- a/src/attr.c
+++ b/src/attr.c
@@ -142,7 +142,7 @@ static int read_server_reply(
 		return -2;
 	}
 	len = ntohl(header->length);
-	rv = tpt->recv(site, msg+len, len-sizeof(*header));
+	rv = tpt->recv(site, msg+sizeof(*header), len-sizeof(*header));
 	if (rv < 0) {
 		return -1;
 	}


### PR DESCRIPTION
Fix reading of server_reply. Also properly check result of gcry_md_get_algo_dlen.

This two patches fixes CVE-2024-3049

Already preaproved by @clumens 