### PR TITLE
Apply config.c refactorings

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -934,56 +934,57 @@ out:
 	return -1;
 }
 
-
-int check_config(int type)
+int check_config(struct booth_config *conf, int type)
 {
 	struct passwd *pw;
 	struct group *gr;
 	char *cp, *input;
 
-	if (!booth_conf)
+	if (conf == NULL) {
 		return -1;
-
+	}
 
 	input = (type == ARBITRATOR)
-		? booth_conf->arb_user
-		: booth_conf->site_user;
+		? conf->arb_user
+		: conf->site_user;
 	if (!*input)
 		goto u_inval;
 	if (isdigit(input[0])) {
-		booth_conf->uid = strtol(input, &cp, 0);
+		conf->uid = strtol(input, &cp, 0);
 		if (*cp != 0) {
 u_inval:
 			log_error("User \"%s\" cannot be resolved into a UID.", input);
 			return ENOENT;
 		}
-	}
-	else {
+	} else {
 		pw = getpwnam(input);
 		if (!pw)
 			goto u_inval;
-		booth_conf->uid = pw->pw_uid;
+		conf->uid = pw->pw_uid;
 	}
 
 
 	input = (type == ARBITRATOR)
-		? booth_conf->arb_group
-		: booth_conf->site_group;
-	if (!*input)
+		? conf->arb_group
+		: conf->site_group;
+
+	if (!*input) {
 		goto g_inval;
+	}
+
 	if (isdigit(input[0])) {
-		booth_conf->gid = strtol(input, &cp, 0);
+		conf->gid = strtol(input, &cp, 0);
 		if (*cp != 0) {
 g_inval:
 			log_error("Group \"%s\" cannot be resolved into a UID.", input);
 			return ENOENT;
 		}
-	}
-	else {
+	} else {
 		gr = getgrnam(input);
-		if (!gr)
+		if (!gr) {
 			goto g_inval;
-		booth_conf->gid = gr->gr_gid;
+		}
+		conf->gid = gr->gr_gid;
 	}
 
 	return 0;

--- a/src/config.h
+++ b/src/config.h
@@ -327,8 +327,17 @@ extern struct booth_config *booth_conf;
 
 #define is_auth_req() (booth_conf->authkey[0] != '\0')
 
-
-int read_config(const char *path, int type);
+/**
+ * @internal
+ * Parse booth configuration file and store as structured data
+ *
+ * @param[in,out] conf config object to free-alloc cycle & fill accordingly
+ * @param[in] path where the configuration file is expected
+ * @param[in] type role currently being acted as
+ *
+ * @return 0 or negative value (-1 or -errno) on error
+ */
+int read_config(struct booth_config **conf, const char *path, int type);
 
 int check_config(int type);
 

--- a/src/config.h
+++ b/src/config.h
@@ -339,7 +339,21 @@ extern struct booth_config *booth_conf;
  */
 int read_config(struct booth_config **conf, const char *path, int type);
 
-int check_config(int type);
+/**
+ * @internal
+ * Check booth configuration
+ *
+ * Checks include:
+ *
+ * - Verifying that the login user and group exist, and converting them to
+ *   numeric values
+ *
+ * @param[in,out] conf_ptr config object to check
+ * @param[in] type role currently being acted as
+ *
+ * @return 0 or negative value (-1 or -errno) on error
+ */
+int check_config(struct booth_config *conf, int type);
 
 int find_site_by_name(char *site, struct booth_site **node, int any_type);
 int find_site_by_id(uint32_t site_id, struct booth_site **node);

--- a/src/main.c
+++ b/src/main.c
@@ -404,7 +404,7 @@ static int setup_config(struct booth_config **conf, int type)
 		find_myself(NULL, type == CLIENT || type == GEOSTORE);
 
 
-	rv = check_config(type);
+	rv = check_config(booth_conf, type);
 	if (rv < 0)
 		goto out;
 

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -88,22 +88,6 @@ int check_ticket(char *ticket, struct ticket_config **found)
 	return find_ticket_by_name(ticket, found);
 }
 
-int check_site(char *site, int *is_local)
-{
-	struct booth_site *node;
-
-	if (!check_max_len_valid(site, sizeof(node->addr_string)))
-		return 0;
-
-	if (find_site_by_name(site, &node, 0)) {
-		*is_local = node->local;
-		return 1;
-	}
-
-	return 0;
-}
-
-
 /* is it safe to commit the grant?
  * if we didn't hear from all sites on the initial grant, we may
  * need to delay the commit

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -97,7 +97,6 @@ void save_committed_tkt(struct ticket_config *tk);
 void disown_ticket(struct ticket_config *tk);
 int disown_if_expired(struct ticket_config *tk);
 int check_ticket(char *ticket, struct ticket_config **tc);
-int check_site(char *site, int *local);
 int grant_ticket(struct ticket_config *ticket);
 int revoke_ticket(struct ticket_config *ticket);
 int list_ticket(char **pdata, unsigned int *len);


### PR DESCRIPTION
Continuing with #82, this is the next couple patches that address the use of global variables in config.[ch].  I made a couple changes to the original patches - get rid of `_ptr` from the variable names, add braces around conditional blocks in code that this touches, and removing a function instead of marking it as unused.

I tested this only briefly, by installing updated packages and making sure that booth started and could grant tickets.

Note - this builds on top of #147 so that needs to be merged first, then I'll rebase this one and it can be merged as well.