### PR TITLE
Apply find_* function refactorings

### DIFF
--- a/src/attr.c
+++ b/src/attr.c
@@ -149,7 +149,7 @@ static int read_server_reply(
 	return rv;
 }
 
-int do_attr_command(cmd_request_t cmd)
+int do_attr_command(struct booth_config *conf, cmd_request_t cmd)
 {
 	struct booth_site *site = NULL;
 	struct boothc_header *header;
@@ -160,7 +160,7 @@ int do_attr_command(cmd_request_t cmd)
 	if (!*cl.site)
 		site = local;
 	else {
-		if (!find_site_by_name(cl.site, &site, 1)) {
+		if (!find_site_by_name(conf, cl.site, &site, 1)) {
 			log_error("Site \"%s\" not configured.", cl.site);
 			goto out_close;
 		}

--- a/src/attr.h
+++ b/src/attr.h
@@ -31,7 +31,18 @@
 
 void print_geostore_usage(void);
 int test_attr_reply(cmd_result_t reply_code, cmd_request_t cmd);
-int do_attr_command(cmd_request_t cmd);
+
+/**
+ * @internal
+ * Carry out a geo-atribute related command
+ *
+ * @param[in,out] conf  config object to refer to
+ * @param[in]     cmd   what to perform
+ *
+ * @return 0 or negative value (-1 or -errno) on error
+ */
+int do_attr_command(struct booth_config *conf, cmd_request_t cmd);
+
 int process_attr_request(struct client *req_client, void *buf);
 int attr_recv(void *buf, struct booth_site *source);
 int store_geo_attr(struct ticket_config *tk, const char *name, const char *val, int notime);

--- a/src/booth.h
+++ b/src/booth.h
@@ -77,6 +77,10 @@
 /* Says that another one should recover. */
 #define TICKET_LOST CHAR2CONST('L', 'O', 'S', 'T')
 
+struct booth_config;
+
+typedef void (*workfn_t)(struct booth_config *conf, int ci);
+
 
 typedef char boothc_site[BOOTH_NAME_LEN];
 typedef char boothc_ticket[BOOTH_NAME_LEN];
@@ -338,7 +342,7 @@ struct client {
 	const struct booth_transport *transport;
 	struct boothc_ticket_msg *msg;
 	int offset; /* bytes read so far into msg */
-	void (*workfn)(int);
+	workfn_t workfn;
 	void (*deadfn)(int);
 };
 
@@ -347,7 +351,7 @@ extern struct pollfd *pollfds;
 
 
 int client_add(int fd, const struct booth_transport *tpt,
-		void (*workfn)(int ci), void (*deadfn)(int ci));
+		workfn_t workfn, void (*deadfn)(int ci));
 int find_client_by_fd(int fd);
 void safe_copy(char *dest, char *value, size_t buflen, const char *description);
 int update_authkey(void);

--- a/src/config.c
+++ b/src/config.c
@@ -991,16 +991,18 @@ g_inval:
 }
 
 
-static int get_other_site(struct booth_site **node)
+static int get_other_site(struct booth_config *conf,
+			  struct booth_site **node)
 {
 	struct booth_site *n;
 	int i;
 
 	*node = NULL;
-	if (!booth_conf)
+	if (conf == NULL) {
 		return 0;
+	}
 
-	_FOREACH_NODE(i, n) {
+	FOREACH_NODE(conf, i, n) {
 		if (n != local && n->type == SITE) {
 			if (!*node) {
 				*node = n;
@@ -1014,18 +1016,21 @@ static int get_other_site(struct booth_site **node)
 }
 
 
-int find_site_by_name(char *site, struct booth_site **node, int any_type)
+int find_site_by_name(struct booth_config *conf, const char *site,
+		      struct booth_site **node, int any_type)
 {
 	struct booth_site *n;
 	int i;
 
-	if (!booth_conf)
+	if (conf == NULL) {
 		return 0;
+	}
 
-	if (!strcmp(site, OTHER_SITE))
-		return get_other_site(node);
+	if (!strcmp(site, OTHER_SITE)) {
+		return get_other_site(conf, node);
+	}
 
-	_FOREACH_NODE(i, n) {
+	FOREACH_NODE(conf, i, n) {
 		if ((n->type == SITE || any_type) &&
 		    strncmp(n->addr_string, site, sizeof(n->addr_string)) == 0) {
 			*node = n;

--- a/src/config.c
+++ b/src/config.c
@@ -1000,7 +1000,7 @@ static int get_other_site(struct booth_site **node)
 	if (!booth_conf)
 		return 0;
 
-	FOREACH_NODE(i, n) {
+	_FOREACH_NODE(i, n) {
 		if (n != local && n->type == SITE) {
 			if (!*node) {
 				*node = n;
@@ -1025,7 +1025,7 @@ int find_site_by_name(char *site, struct booth_site **node, int any_type)
 	if (!strcmp(site, OTHER_SITE))
 		return get_other_site(node);
 
-	FOREACH_NODE(i, n) {
+	_FOREACH_NODE(i, n) {
 		if ((n->type == SITE || any_type) &&
 		    strncmp(n->addr_string, site, sizeof(n->addr_string)) == 0) {
 			*node = n;
@@ -1049,7 +1049,7 @@ int find_site_by_id(uint32_t site_id, struct booth_site **node)
 	if (!booth_conf)
 		return 0;
 
-	FOREACH_NODE(i, n) {
+	_FOREACH_NODE(i, n) {
 		if (n->site_id == site_id) {
 			*node = n;
 			return 1;

--- a/src/config.c
+++ b/src/config.c
@@ -1041,7 +1041,8 @@ int find_site_by_name(struct booth_config *conf, const char *site,
 	return 0;
 }
 
-int find_site_by_id(uint32_t site_id, struct booth_site **node)
+int find_site_by_id(struct booth_config *conf,
+		    uint32_t site_id, struct booth_site **node)
 {
 	struct booth_site *n;
 	int i;
@@ -1051,10 +1052,11 @@ int find_site_by_id(uint32_t site_id, struct booth_site **node)
 		return 1;
 	}
 
-	if (!booth_conf)
+	if (conf == NULL) {
 		return 0;
+	}
 
-	_FOREACH_NODE(i, n) {
+	FOREACH_NODE(conf, i, n) {
 		if (n->site_id == site_id) {
 			*node = n;
 			return 1;
@@ -1063,7 +1065,6 @@ int find_site_by_id(uint32_t site_id, struct booth_site **node)
 
 	return 0;
 }
-
 
 const char *type_to_string(int type)
 {

--- a/src/config.h
+++ b/src/config.h
@@ -25,6 +25,17 @@
 #include "booth.h"
 #include "timer.h"
 #include "raft.h"
+
+/* Forward declaration of the booth config structure that will be defined later.
+ * This is necessary here because transport.h references booth_config, but this
+ * file also references transport_layer_t.  We need some way to break the
+ * circular dependency.
+ *
+ * This also means that config.h must always be included before transport.h in
+ * any source files.
+ */
+struct booth_config;
+
 #include "transport.h"
 
 
@@ -369,7 +380,19 @@ int check_config(struct booth_config *conf, int type);
 int find_site_by_name(struct booth_config *conf, const char *site,
 		      struct booth_site **node, int any_type);
 
-int find_site_by_id(uint32_t site_id, struct booth_site **node);
+
+/**
+ * @internal
+ * Find site in booth configuration by a hash (id)
+ *
+ * @param[in,out] conf config object to refer to
+ * @param[in] site_id hash (id) to match against previously resolved ones
+ * @param[out] node relevant tracked data when found
+ *
+ * @return 0 if nothing found, or 1 when found (node assigned accordingly)
+ */
+int find_site_by_id(struct booth_config *conf, uint32_t site_id,
+		    struct booth_site **node);
 
 const char *type_to_string(int type);
 

--- a/src/config.h
+++ b/src/config.h
@@ -355,7 +355,20 @@ int read_config(struct booth_config **conf, const char *path, int type);
  */
 int check_config(struct booth_config *conf, int type);
 
-int find_site_by_name(char *site, struct booth_site **node, int any_type);
+/**
+ * @internal
+ * Find site in booth configuration by resolved host name
+ *
+ * @param[in,out] conf config object to refer to
+ * @param[in] site name to match against previously resolved host names
+ * @param[out] node relevant tracked data when found
+ * @param[in] any_type whether or not to consider also non-site members
+ *
+ * @return 0 if nothing found, or 1 when found (node assigned accordingly)
+ */
+int find_site_by_name(struct booth_config *conf, const char *site,
+		      struct booth_site **node, int any_type);
+
 int find_site_by_id(uint32_t site_id, struct booth_site **node);
 
 const char *type_to_string(int type);

--- a/src/handler.c
+++ b/src/handler.c
@@ -133,7 +133,7 @@ void wait_child(int sig)
 	/* use waitpid(2) and not wait(2) in order not to interfere
 	 * with popen(2)/pclose(2) and system(2) used in pacemaker.c
 	 */
-	FOREACH_TICKET(i, tk) {
+	_FOREACH_TICKET(i, tk) {
 		if (tk_test.path && tk_test.pid > 0 &&
 				(tk_test.progstate == EXTPROG_RUNNING ||
 				tk_test.progstate == EXTPROG_IGNORE) &&

--- a/src/main.c
+++ b/src/main.c
@@ -394,7 +394,7 @@ static int setup_config(struct booth_config **conf, int type)
 
 	/* Set "local" pointer, ignoring errors. */
 	if (cl.type == DAEMON && cl.site[0]) {
-		if (!find_site_by_name(cl.site, &local, 1)) {
+		if (!find_site_by_name(booth_conf, cl.site, &local, 1)) {
 			log_error("Cannot find \"%s\" in the configuration.",
 					cl.site);
 			return -EINVAL;
@@ -708,7 +708,7 @@ static int query_get_string_answer(cmd_request_t cmd)
 
 	if (!*cl.site)
 		site = local;
-	else if (!find_site_by_name(cl.site, &site, 1)) {
+	else if (!find_site_by_name(booth_conf, cl.site, &site, 1)) {
 		log_error("cannot find site \"%s\"", cl.site);
 		rv = ENOENT;
 		goto out;
@@ -782,7 +782,7 @@ static int do_command(cmd_request_t cmd)
 	if (!*cl.site)
 		site = local;
 	else {
-		if (!find_site_by_name(cl.site, &site, 1)) {
+		if (!find_site_by_name(booth_conf, cl.site, &site, 1)) {
 			log_error("Site \"%s\" not configured.", cl.site);
 			goto out_close;
 		}
@@ -1617,7 +1617,7 @@ static int do_attr(struct booth_config **conf)
 
 	case ATTR_SET:
 	case ATTR_DEL:
-		rv = do_attr_command(cl.op);
+		rv = do_attr_command(booth_conf, cl.op);
 		break;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -399,9 +399,9 @@ static int setup_config(struct booth_config **conf, int type)
 			return -EINVAL;
 		}
 		local->local = 1;
-	} else
-		find_myself(NULL, type == CLIENT || type == GEOSTORE);
-
+	} else {
+		find_myself(booth_conf, NULL, type == CLIENT || type == GEOSTORE);
+	}
 
 	rv = check_config(booth_conf, type);
 	if (rv < 0)

--- a/src/main.c
+++ b/src/main.c
@@ -233,7 +233,7 @@ static int format_peers(char **pdata, unsigned int *len)
 		return -ENOMEM;
 
 	cp = data;
-	FOREACH_NODE(i, s) {
+	_FOREACH_NODE(i, s) {
 		if (s == local)
 			continue;
 		strftime(time_str, sizeof(time_str), "%F %T",

--- a/src/manual.c
+++ b/src/manual.c
@@ -18,9 +18,9 @@
 
 #include "manual.h"
 
+#include "config.h"
 #include "transport.h"
 #include "ticket.h"
-#include "config.h"
 #include "log.h"
 #include "request.h"
 

--- a/src/pacemaker.h
+++ b/src/pacemaker.h
@@ -26,7 +26,7 @@
 struct ticket_handler {
 	int (*grant_ticket) (struct ticket_config *tk);
 	int (*revoke_ticket) (struct ticket_config *tk);
-	int (*load_ticket) (struct ticket_config *tk);
+	int (*load_ticket) (struct booth_config *conf, struct ticket_config *tk);
 	int (*set_attr) (struct ticket_config *tk, const char *a, const char *v);
 	int (*get_attr) (struct ticket_config *tk, const char *a, const char **vp);
 	int (*del_attr) (struct ticket_config *tk, const char *a);

--- a/src/raft.c
+++ b/src/raft.c
@@ -23,9 +23,9 @@
 #include <arpa/inet.h>
 #include "booth.h"
 #include "timer.h"
+#include "config.h"
 #include "transport.h"
 #include "inline-fn.h"
-#include "config.h"
 #include "raft.h"
 #include "ticket.h"
 #include "request.h"

--- a/src/raft.c
+++ b/src/raft.c
@@ -40,7 +40,7 @@ inline static void clear_election(struct ticket_config *tk)
 
 	tk_log_debug("clear election");
 	tk->votes_received = 0;
-	FOREACH_NODE(i, site) {
+	_FOREACH_NODE(i, site) {
 		tk->votes_for[site->index] = NULL;
 	}
 }

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -65,7 +65,7 @@ int find_ticket_by_name(const char *ticket, struct ticket_config **found)
 	if (found)
 		*found = NULL;
 
-	FOREACH_TICKET(i, tk) {
+	_FOREACH_TICKET(i, tk) {
 		if (!strncmp(tk->name, ticket, sizeof(tk->name))) {
 			if (found)
 				*found = tk;
@@ -390,7 +390,7 @@ int list_ticket(char **pdata, unsigned int *len)
 
 	alloc = booth_conf->ticket_count * (BOOTH_NAME_LEN * 2 + 128 + 16);
 
-	FOREACH_TICKET(i, tk) {
+	_FOREACH_TICKET(i, tk) {
 		multiple_grant_warning_length = number_sites_marked_as_granted(tk);
 
 		if (multiple_grant_warning_length > 1) {
@@ -404,7 +404,7 @@ int list_ticket(char **pdata, unsigned int *len)
 		return -ENOMEM;
 
 	cp = data;
-	FOREACH_TICKET(i, tk) {
+	_FOREACH_TICKET(i, tk) {
 		if ((!is_manual(tk)) && is_time_set(&tk->term_expires)) {
 			/* Manual tickets doesn't have term_expires defined */
 			ts = wall_ts(&tk->term_expires);
@@ -452,7 +452,7 @@ int list_ticket(char **pdata, unsigned int *len)
 		}
 	}
 
-	FOREACH_TICKET(i, tk) {
+	_FOREACH_TICKET(i, tk) {
 		multiple_grant_warning_length = number_sites_marked_as_granted(tk);
 
 		if (multiple_grant_warning_length > 1) {
@@ -461,7 +461,7 @@ int list_ticket(char **pdata, unsigned int *len)
 					"\nWARNING: The ticket %s is granted to multiple sites: ",  // ~55 characters
 					tk->name);
 
-			FOREACH_NODE(site_index, site) {
+			_FOREACH_NODE(site_index, site) {
 				if (tk->sites_where_granted[site_index] > 0) {
 					cp += snprintf(cp,
 						alloc - (cp - data),
@@ -617,7 +617,7 @@ int setup_ticket(void)
 	struct ticket_config *tk;
 	int i;
 
-	FOREACH_TICKET(i, tk) {
+	_FOREACH_TICKET(i, tk) {
 		reset_ticket(tk);
 
 		if (local->type == SITE) {
@@ -844,7 +844,7 @@ static void log_lost_servers(struct ticket_config *tk)
 		 */
 		return;
 
-	FOREACH_NODE(i, n) {
+	_FOREACH_NODE(i, n) {
 		if (!(tk->acks_received & n->bitmask)) {
 			tk_log_warn("%s %s didn't acknowledge our %s, "
 			"will retry %d times",
@@ -864,7 +864,7 @@ static void resend_msg(struct ticket_config *tk)
 	if (!(tk->acks_received ^ local->bitmask)) {
 		ticket_broadcast(tk, tk->last_request, 0, RLT_SUCCESS, 0);
 	} else {
-		FOREACH_NODE(i, n) {
+		_FOREACH_NODE(i, n) {
 			if (!(tk->acks_received & n->bitmask)) {
 				n->resend_cnt++;
 				tk_log_debug("resending %s to %s",
@@ -1128,7 +1128,7 @@ void process_tickets(void)
 	int i;
 	timetype last_cron;
 
-	FOREACH_TICKET(i, tk) {
+	_FOREACH_TICKET(i, tk) {
 		if (!has_extprog_exited(tk) &&
 				is_time_set(&tk->next_cron) && !is_past(&tk->next_cron))
 			continue;
@@ -1152,7 +1152,7 @@ void tickets_log_info(void)
 	int i;
 	time_t ts;
 
-	FOREACH_TICKET(i, tk) {
+	_FOREACH_TICKET(i, tk) {
 		ts = wall_ts(&tk->term_expires);
 		tk_log_info("state '%s' "
 				"term %d "
@@ -1350,7 +1350,7 @@ int number_sites_marked_as_granted(struct ticket_config *tk)
 	int i, result = 0;
 	struct booth_site *ignored __attribute__((unused));
 
-	FOREACH_NODE(i, ignored) {
+	_FOREACH_NODE(i, ignored) {
 		result += tk->sites_where_granted[i];
 	}
 

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -612,16 +612,16 @@ void update_ticket_state(struct ticket_config *tk, struct booth_site *sender)
 	}
 }
 
-int setup_ticket(void)
+int setup_ticket(struct booth_config *conf)
 {
 	struct ticket_config *tk;
 	int i;
 
-	_FOREACH_TICKET(i, tk) {
+	FOREACH_TICKET(conf, i, tk) {
 		reset_ticket(tk);
 
 		if (local->type == SITE) {
-			if (!pcmk_handler.load_ticket(tk)) {
+			if (!pcmk_handler.load_ticket(conf, tk)) {
 				update_ticket_state(tk, NULL);
 			}
 			tk->update_cib = 1;
@@ -1197,7 +1197,7 @@ static void update_acks(
 }
 
 /* read ticket message */
-int ticket_recv(void *buf, struct booth_site *source)
+int ticket_recv(struct booth_config *conf, void *buf, struct booth_site *source)
 {
 	struct boothc_ticket_msg *msg;
 	struct ticket_config *tk;
@@ -1215,7 +1215,7 @@ int ticket_recv(void *buf, struct booth_site *source)
 
 
 	leader_u = ntohl(msg->ticket.leader);
-	if (!find_site_by_id(leader_u, &leader)) {
+	if (!find_site_by_id(conf, leader_u, &leader)) {
 		tk_log_error("message with unknown leader %u received", leader_u);
 		source->invalid_cnt++;
 		return -EINVAL;

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -112,11 +112,32 @@ int grant_ticket(struct ticket_config *ticket);
 int revoke_ticket(struct ticket_config *ticket);
 int list_ticket(char **pdata, unsigned int *len);
 
-int ticket_recv(void *buf, struct booth_site *source);
+/**
+ * @internal
+ * Second stage of incoming datagram handling (after authentication)
+ *
+ * @param[in,out] conf config object to refer to
+ * @param[in] buf raw message to act upon
+ * @param[in] source member originating this message
+ *
+ * @return 0 on success or negative value (-1 or -errno) on error
+ */
+int ticket_recv(struct booth_config *conf, void *buf, struct booth_site *source);
+
 void reset_ticket(struct ticket_config *tk);
 void reset_ticket_and_set_no_leader(struct ticket_config *tk);
 void update_ticket_state(struct ticket_config *tk, struct booth_site *sender);
-int setup_ticket(void);
+
+/**
+ * @internal
+ * Broadcast the initial state query
+ *
+ * @param[in,out] conf config object to use as a starting point
+ *
+ * @return 0 (for the time being)
+ */
+int setup_ticket(struct booth_config *conf);
+
 int check_max_len_valid(const char *s, int max);
 
 int do_grant_ticket(struct ticket_config *ticket, int options);

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -35,12 +35,12 @@ extern int TIME_RES;
 #define DEFAULT_RETRIES			10
 
 
-#define FOREACH_TICKET(i_, t_) \
+#define _FOREACH_TICKET(i_, t_) \
 	for (i_ = 0; \
 	     (t_ = booth_conf->ticket + i_, i_ < booth_conf->ticket_count); \
 	     i_++)
 
-#define FOREACH_NODE(i_, n_) \
+#define _FOREACH_NODE(i_, n_) \
 	for (i_ = 0; \
 	     (n_ = booth_conf->site + i_, i_ < booth_conf->site_count); \
 	     i_++)

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -35,6 +35,17 @@ extern int TIME_RES;
 #define DEFAULT_RETRIES			10
 
 
+#define FOREACH_TICKET(b_, i_, t_) \
+	for (i_ = 0; \
+	     (t_ = (b_)->ticket + i_, i_ < (b_)->ticket_count); \
+	     i_++)
+
+#define FOREACH_NODE(b_, i_, n_) \
+	for (i_ = 0; \
+	     (n_ = (b_)->site + i_, i_ < (b_)->site_count); \
+	     i_++)
+
+
 #define _FOREACH_TICKET(i_, t_) \
 	for (i_ = 0; \
 	     (t_ = booth_conf->ticket + i_, i_ < booth_conf->ticket_count); \

--- a/src/transport.c
+++ b/src/transport.c
@@ -98,7 +98,7 @@ static int find_address(unsigned char ipaddr[BOOTH_IPADDR_LEN],
 	/* One bit left to check means ignore 7 lowest bits. */
 	mask = ~( (1 << (8 - bits_left)) -1);
 
-	FOREACH_NODE(i, node) {
+	_FOREACH_NODE(i, node) {
 		if (family != node->family)
 			continue;
 		n_a = node_to_addr_pointer(node);
@@ -900,7 +900,7 @@ static int booth_udp_broadcast_auth(void *buf, int len)
 		return rv;
 
 	rvs = 0;
-	FOREACH_NODE(i, site) {
+	_FOREACH_NODE(i, site) {
 		if (site != local) {
 			rv = booth_udp_send(site, buf, len);
 			if (!rvs)

--- a/src/transport.h
+++ b/src/transport.h
@@ -70,7 +70,17 @@ int booth_udp_send_auth(struct booth_site *to, void *buf, int len);
 int booth_tcp_open(struct booth_site *to);
 int booth_tcp_send(struct booth_site *to, void *buf, int len);
 
-int message_recv(void *msg, int msglen);
+/**
+ * @internal
+ * First stage of incoming datagram handling (authentication)
+ *
+ * @param[in,out] conf config object to refer to
+ * @param[in] msg raw message to act upon
+ * @param[in] msglen length of #msg
+ *
+ * @return 0 on success or negative value (-1 or -errno) on error
+ */
+int message_recv(struct booth_config *conf, void *msg, int msglen);
 
 inline static void * node_to_addr_pointer(struct booth_site *node) {
 	switch (node->family) {

--- a/src/transport.h
+++ b/src/transport.h
@@ -58,7 +58,19 @@ struct booth_transport {
 };
 
 extern const struct booth_transport booth_transport[TRANSPORT_ENTRIES];
-int find_myself(struct booth_site **me, int fuzzy_allowed);
+
+/**
+ * @internal
+ * Attempts to pick identity of self from config-tracked enumeration of sites
+ *
+ * @param[in,out] conf config object to refer to
+ * @param[out] mep when self-discovery successful, site pointer is stored here
+ * @param[in] fuzzy_allowed whether it's OK to approximate the match
+ *
+ * @return 0 on success or negative value (-1 or -errno) on error
+ */
+int find_myself(struct booth_config *conf, struct booth_site **me,
+		int fuzzy_allowed);
 
 int read_client(struct client *req_cl);
 int check_boothc_header(struct boothc_header *data, int len_incl_data);


### PR DESCRIPTION
This is the next batch of refactorings from PR #82, though there are a couple differences from what's in those patches:

* Note the FOREACH_NODE -> _FOREACH_NODE stuff.  Basically, I renamed it and added a new version that takes an additional config pointer argument so I don't have to update all callers everywhere at once, along with all their callers, and so on.

* These patches built, but would crash because message_recv has a new parameter, but that function is only ever indirectly called through function pointers, and the use of those pointers did not pass the config pointer.  So, various other places had to get that argument added.  I did not check very hard to see how this gets handled in the original PR in later patches.

* I added a function pointer type to simplify having to deal with the above.