### PR TITLE
Additional refactorings in ticket.c

### DIFF
--- a/src/attr.c
+++ b/src/attr.c
@@ -406,7 +406,8 @@ static cmd_result_t attr_list(struct ticket_config *tk, int fd, struct boothc_at
 	return rv;
 }
 
-int process_attr_request(struct client *req_client, void *buf)
+int process_attr_request(struct booth_config *conf, struct client *req_client,
+			 void *buf)
 {
 	cmd_result_t rv = RLT_SYNC_FAIL;
 	struct ticket_config *tk;
@@ -416,7 +417,7 @@ int process_attr_request(struct client *req_client, void *buf)
 
 	msg = (struct boothc_attr_msg *)buf;
 	cmd = ntohl(msg->header.cmd);
-	if (!check_ticket(msg->attr.tkt_id, &tk)) {
+	if (!check_ticket(conf, msg->attr.tkt_id, &tk)) {
 		log_warn("client referenced unknown ticket %s",
 				msg->attr.tkt_id);
 		rv = RLT_INVALID_ARG;
@@ -454,7 +455,7 @@ reply_now:
  * only clients retrieve/manage attributes and they connect
  * directly to the target site
  */
-int attr_recv(void *buf, struct booth_site *source)
+int attr_recv(struct booth_config *conf, void *buf, struct booth_site *source)
 {
 	struct boothc_attr_msg *msg;
 	struct ticket_config *tk;
@@ -464,7 +465,7 @@ int attr_recv(void *buf, struct booth_site *source)
 	log_warn("unexpected attribute message from %s",
 			site_string(source));
 
-	if (!check_ticket(msg->attr.tkt_id, &tk)) {
+	if (!check_ticket(conf, msg->attr.tkt_id, &tk)) {
 		log_warn("got invalid ticket name %s from %s",
 				msg->attr.tkt_id, site_string(source));
 		source->invalid_cnt++;

--- a/src/attr.h
+++ b/src/attr.h
@@ -43,8 +43,31 @@ int test_attr_reply(cmd_result_t reply_code, cmd_request_t cmd);
  */
 int do_attr_command(struct booth_config *conf, cmd_request_t cmd);
 
-int process_attr_request(struct client *req_client, void *buf);
-int attr_recv(void *buf, struct booth_site *source);
+/**
+ * @internal
+ * Handle geostore related operations
+ *
+ * @param[in,out] conf       config object to refer to
+ * @param[in]     req_client client structure of the sender
+ * @param[in]     buf        client message
+ *
+ * @return 1 or see #attr_list, #attr_get, #attr_set, and #attr_del
+ */
+int process_attr_request(struct booth_config *conf, struct client *req_client,
+			 void *buf);
+
+/**
+ * @internal
+ * Second stage of incoming message handling (after authentication)
+ *
+ * @param[in,out] conf   config object to refer to
+ * @param[in]     buf    incoming message
+ * @param[in]     source site of the sender
+ *
+ * @return -1 on error, 0 otherwise
+ */
+int attr_recv(struct booth_config *conf, void *buf, struct booth_site *source);
+
 int store_geo_attr(struct ticket_config *tk, const char *name, const char *val, int notime);
 
 #endif /* _ATTR_H */

--- a/src/config.c
+++ b/src/config.c
@@ -289,7 +289,7 @@ static int add_ticket(struct booth_config *conf, const char *name,
 		return -EINVAL;
 	}
 
-	if (find_ticket_by_name(name, NULL)) {
+	if (find_ticket_by_name(conf, name, NULL)) {
 		log_error("ticket name \"%s\" used again.", name);
 		return -EINVAL;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -507,7 +507,7 @@ static int process_signals(void)
 	}
 	if (sig_usr1_handler_called) {
 		sig_usr1_handler_called = 0;
-		tickets_log_info();
+		tickets_log_info(booth_conf);
 	}
 	if (sig_chld_handler_called) {
 		sig_chld_handler_called = 0;
@@ -570,7 +570,7 @@ static int loop(int fd)
 			}
 		}
 
-		process_tickets();
+		process_tickets(booth_conf);
 
 		if (process_signals() != 0) {
 			return 0;

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -382,6 +382,18 @@ int do_revoke_ticket(struct ticket_config *tk)
 	}
 }
 
+static int number_sites_marked_as_granted(struct ticket_config *tk)
+{
+	int i, result = 0;
+	struct booth_site *ignored __attribute__((unused));
+
+	_FOREACH_NODE(i, ignored) {
+		result += tk->sites_where_granted[i];
+	}
+
+	return result;
+}
+
 
 int list_ticket(char **pdata, unsigned int *len)
 {
@@ -1356,20 +1368,6 @@ int is_manual(struct ticket_config *tk)
 {
 	return (tk->mode == TICKET_MODE_MANUAL) ? 1 : 0;
 }
-
-int number_sites_marked_as_granted(struct ticket_config *tk)
-{
-	int i, result = 0;
-	struct booth_site *ignored __attribute__((unused));
-
-	_FOREACH_NODE(i, ignored) {
-		result += tk->sites_where_granted[i];
-	}
-
-	return result;
-}
-
-
 
 /* Given a state (in host byte order), return a human-readable (char*).
  * An array is used so that multiple states can be printed in a single printf(). */

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -289,7 +289,7 @@ static int do_ext_prog(struct ticket_config *tk,
  * to start the program, and then to get the result and start
  * elections.
  */
-int acquire_ticket(struct ticket_config *tk, cmd_reason_t reason)
+static int acquire_ticket(struct ticket_config *tk, cmd_reason_t reason)
 {
 	int rv;
 
@@ -319,7 +319,7 @@ int acquire_ticket(struct ticket_config *tk, cmd_reason_t reason)
 
 /** Try to get the ticket for the local site.
  * */
-int do_grant_ticket(struct ticket_config *tk, int options)
+static int do_grant_ticket(struct ticket_config *tk, int options)
 {
 	int rv;
 
@@ -370,7 +370,7 @@ static void start_revoke_ticket(struct ticket_config *tk)
 
 /** Ticket revoke.
  * Only to be started from the leader. */
-int do_revoke_ticket(struct ticket_config *tk)
+static int do_revoke_ticket(struct ticket_config *tk)
 {
 	if (tk->acks_expected) {
 		tk_log_info("delay ticket revoke until the current operation finishes");
@@ -520,17 +520,6 @@ void disown_ticket(struct ticket_config *tk)
 	set_leader(tk, NULL);
 	tk->is_granted = 0;
 	get_time(&tk->term_expires);
-}
-
-int disown_if_expired(struct ticket_config *tk)
-{
-	if (is_past(&tk->term_expires) ||
-			!tk->leader) {
-		disown_ticket(tk);
-		return 1;
-	}
-
-	return 0;
 }
 
 void reset_ticket(struct ticket_config *tk)
@@ -946,7 +935,7 @@ just_resend:
 	resend_msg(conf, tk);
 }
 
-int postpone_ticket_processing(struct ticket_config *tk)
+static int postpone_ticket_processing(struct ticket_config *tk)
 {
 	extern timetype start_time;
 

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -107,7 +107,19 @@ extern int TIME_RES;
 void save_committed_tkt(struct ticket_config *tk);
 void disown_ticket(struct ticket_config *tk);
 int disown_if_expired(struct ticket_config *tk);
-int check_ticket(char *ticket, struct ticket_config **tc);
+
+/**
+ * @internal
+ * Like @find_ticket_by_name, but perform sanity checks on the found ticket
+ *
+ * @param[in,out] conf   config object to refer to
+ * @param[in]     ticket name of the ticket to search for
+ * @param[out]    found  place the reference here when found
+ *
+ * @return 0 on failure, see @find_ticket_by_name otherwise
+ */
+int check_ticket(struct booth_config *conf, char *ticket, struct ticket_config **tc);
+
 int grant_ticket(struct ticket_config *ticket);
 int revoke_ticket(struct ticket_config *ticket);
 int list_ticket(char **pdata, unsigned int *len);
@@ -143,7 +155,18 @@ int check_max_len_valid(const char *s, int max);
 int do_grant_ticket(struct ticket_config *ticket, int options);
 int do_revoke_ticket(struct ticket_config *tk);
 
-int find_ticket_by_name(const char *ticket, struct ticket_config **found);
+/**
+ * @internal
+ * Find a ticket based on a given name
+ *
+ * @param[in,out] conf   config object to refer to
+ * @param[in]     ticket name of the ticket to search for
+ * @param[out]    found  place the reference here when found
+ *
+ * @return see @list_ticket and @send_header_plus
+ */
+int find_ticket_by_name(struct booth_config *conf,
+			const char *ticket, struct ticket_config **found);
 
 void set_ticket_wakeup(struct ticket_config *tk);
 int postpone_ticket_processing(struct ticket_config *tk);
@@ -151,7 +174,19 @@ int postpone_ticket_processing(struct ticket_config *tk);
 int acquire_ticket(struct ticket_config *tk, cmd_reason_t reason);
 
 int ticket_answer_list(int fd);
-int process_client_request(struct client *req_client, void *buf);
+
+/**
+ * @internal
+ * Process request from the client (as opposed to the peer daemon)
+ *
+ * @param[in,out] conf       config object to refer to
+ * @param[in]     req_client client structure of the sender
+ * @param[in]     buf        client message
+ *
+ * @return 1 on success, or 0 when not yet done with the message
+ */
+int process_client_request(struct booth_config *conf, struct client *req_client,
+			   void *buf);
 
 int ticket_write(struct ticket_config *tk);
 

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -122,7 +122,6 @@ int check_ticket(struct booth_config *conf, char *ticket, struct ticket_config *
 
 int grant_ticket(struct ticket_config *ticket);
 int revoke_ticket(struct ticket_config *ticket);
-int list_ticket(char **pdata, unsigned int *len);
 
 /**
  * @internal
@@ -173,7 +172,16 @@ int postpone_ticket_processing(struct ticket_config *tk);
 
 int acquire_ticket(struct ticket_config *tk, cmd_reason_t reason);
 
-int ticket_answer_list(int fd);
+/**
+ * @internal
+ * Implementation of ticket listing
+ *
+ * @param[in,out] conf config object to refer to
+ * @param[in]     fd   file descriptor of the socket to respond to
+ *
+ * @return see @list_ticket and @send_header_plus
+ */
+int ticket_answer_list(struct booth_config *conf, int fd);
 
 /**
  * @internal
@@ -190,8 +198,22 @@ int process_client_request(struct booth_config *conf, struct client *req_client,
 
 int ticket_write(struct ticket_config *tk);
 
-void process_tickets(void);
-void tickets_log_info(void);
+/**
+ * @internal
+ * Mainloop of booth ticket handling
+ *
+ * @param[in,out] conf config object to refer to
+ */
+void process_tickets(struct booth_config *conf);
+
+/**
+ * @internal
+ * Log properties of all tickets
+ *
+ * @param[in,out] conf config object to refer to
+ */
+void tickets_log_info(struct booth_config *conf);
+
 char *state_to_string(uint32_t state_ho);
 int send_reject(struct booth_site *dest, struct ticket_config *tk,
 	cmd_result_t code, struct boothc_ticket_msg *in_msg);

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -106,7 +106,6 @@ extern int TIME_RES;
 
 void save_committed_tkt(struct ticket_config *tk);
 void disown_ticket(struct ticket_config *tk);
-int disown_if_expired(struct ticket_config *tk);
 
 /**
  * @internal
@@ -151,9 +150,6 @@ int setup_ticket(struct booth_config *conf);
 
 int check_max_len_valid(const char *s, int max);
 
-int do_grant_ticket(struct ticket_config *ticket, int options);
-int do_revoke_ticket(struct ticket_config *tk);
-
 /**
  * @internal
  * Find a ticket based on a given name
@@ -168,9 +164,6 @@ int find_ticket_by_name(struct booth_config *conf,
 			const char *ticket, struct ticket_config **found);
 
 void set_ticket_wakeup(struct ticket_config *tk);
-int postpone_ticket_processing(struct ticket_config *tk);
-
-int acquire_ticket(struct ticket_config *tk, cmd_reason_t reason);
 
 /**
  * @internal

--- a/src/ticket.h
+++ b/src/ticket.h
@@ -206,7 +206,6 @@ void add_random_delay(struct ticket_config *tk);
 void schedule_election(struct ticket_config *tk, cmd_reason_t reason);
 
 int is_manual(struct ticket_config *tk);
-int number_sites_marked_as_granted(struct ticket_config *tk);
 
 int check_attr_prereq(struct ticket_config *tk, grant_type_e grant_type);
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -465,7 +465,7 @@ static void process_connection(struct booth_config *conf, int ci)
 	 * result a second later? */
 	switch (ntohl(header->cmd)) {
 	case CMD_LIST:
-		ticket_answer_list(req_cl->fd);
+		ticket_answer_list(conf, req_cl->fd);
 		goto kill;
 	case CMD_PEERS:
 		list_peers(req_cl->fd);

--- a/src/transport.c
+++ b/src/transport.c
@@ -473,19 +473,21 @@ static void process_connection(struct booth_config *conf, int ci)
 
 	case CMD_GRANT:
 	case CMD_REVOKE:
-		if (process_client_request(req_cl, msg) == 1)
+		if (process_client_request(conf, req_cl, msg) == 1) {
 			goto kill; /* request processed definitely, close connection */
-		else
+		} else {
 			return;
+		}
 
 	case ATTR_LIST:
 	case ATTR_GET:
 	case ATTR_SET:
 	case ATTR_DEL:
-		if (process_attr_request(req_cl, msg) == 1)
+		if (process_attr_request(conf, req_cl, msg) == 1) {
 			goto kill; /* request processed definitely, close connection */
-		else
+		} else {
 			return;
+		}
 
 	default:
 		log_error("connection %d cmd %x unknown",
@@ -1143,7 +1145,7 @@ int message_recv(struct booth_config *conf, void *msg, int msglen)
 		/* not used, clients send/retrieve attributes directly
 		 * from sites
 		 */
-		return attr_recv(msg, source);
+		return attr_recv(conf, msg, source);
 	} else {
 		return ticket_recv(conf, msg, source);
 	}


### PR DESCRIPTION
This removes the global booth_conf variable from find_ticket_by_name, which lets us remove it from the rest of ticket.c.